### PR TITLE
feat: Componenterize blocklist

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -23,6 +23,7 @@ WKC_METRICS_RESET_AT_NIGHT=false
 WORLD_CONTENT_URL=https://worlds-content-server.decentraland.org
 CATALYST_CONTENT_URL=https://peer.decentraland.org/content
 PLACES_API_URL=https://places.decentraland.org/api
+BLACKLIST_JSON_URL=https://config.decentraland.org/denylist.json
 WORLD_ROOM_PREFIX=
 SCENE_ROOM_PREFIX=
 PROD_LIVEKIT_HOST=

--- a/src/adapters/blocklist.ts
+++ b/src/adapters/blocklist.ts
@@ -1,0 +1,34 @@
+import { AppComponents } from '../types'
+
+export type IBlockListComponent = {
+  isBlacklisted: (identity: string) => Promise<boolean>
+}
+
+export async function createBlockListComponent(
+  components: Pick<AppComponents, 'config' | 'fetch'>
+): Promise<IBlockListComponent> {
+  const { config, fetch } = components
+
+  const blacklistUrl = await config.requireString('BLACKLIST_JSON_URL')
+
+  async function fetchBlacklistedWallets(): Promise<Set<string>> {
+    const response = await fetch.fetch(blacklistUrl)
+    if (!response.ok) {
+      throw new Error(`Failed to fetch deny list, status: ${response.status}`)
+    }
+    const data = await response.json()
+    if (data.users && Array.isArray(data.users)) {
+      return new Set(data.users.map((user: { wallet: string }) => user.wallet.toLowerCase()))
+    }
+    return new Set()
+  }
+
+  async function isBlacklisted(identity: string): Promise<boolean> {
+    const denyList = await fetchBlacklistedWallets()
+    return denyList.has(identity.toLowerCase())
+  }
+
+  return {
+    isBlacklisted
+  }
+}

--- a/src/components.ts
+++ b/src/components.ts
@@ -10,6 +10,7 @@ import { createLivekitComponent } from './adapters/livekit'
 import { createSceneAdminManagerComponent } from './adapters/scene-admin-manager'
 import { createPgComponent } from '@well-known-components/pg-component'
 import { resolve } from 'path'
+import { createBlockListComponent } from './adapters/blocklist'
 
 // Initialize all the components of the app
 export async function initComponents(): Promise<AppComponents> {
@@ -26,6 +27,7 @@ export async function initComponents(): Promise<AppComponents> {
   )
   const statusChecks = await createStatusCheckComponent({ server, config })
   const fetch = createFetchComponent()
+  const blockList = await createBlockListComponent({ config, fetch })
 
   await instrumentHttpServerWithMetrics({ metrics, server, config })
 
@@ -59,6 +61,7 @@ export async function initComponents(): Promise<AppComponents> {
   const sceneFetcher = await createSceneFetcherComponent({ config, logs, fetch })
 
   return {
+    blockList,
     config,
     logs,
     server,

--- a/src/controllers/handlers/utils.ts
+++ b/src/controllers/handlers/utils.ts
@@ -57,15 +57,3 @@ export function validateFilters(filters: { admin?: string }): {
     }
   }
 }
-
-export async function fetchBlacklistedWallets(blackListJson: string): Promise<Set<string>> {
-  const response = await fetch(blackListJson)
-  if (!response.ok) {
-    throw new Error(`Failed to fetch deny list, status: ${response.status}`)
-  }
-  const data = await response.json()
-  if (data.users && Array.isArray(data.users)) {
-    return new Set(data.users.map((user: { wallet: string }) => user.wallet.toLocaleLowerCase()))
-  }
-  return new Set()
-}

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ import type {
 import { DecentralandSignatureContext } from '@dcl/platform-crypto-middleware'
 import { metricDeclarations } from './metrics'
 import { ILivekitComponent } from './adapters/livekit'
+import { IBlockListComponent } from './adapters/blocklist'
 import { IPgComponent } from '@well-known-components/pg-component'
 
 export type ISceneFetcherComponent = IBaseComponent & {
@@ -28,6 +29,7 @@ export type GlobalContext = {
 
 export type BaseComponents = {
   config: IConfigComponent
+  blockList: IBlockListComponent
   logs: ILoggerComponent
   server: IHttpServerComponent<GlobalContext>
   fetch: IFetchComponent

--- a/test/unit/blocklist-adapter.spec.ts
+++ b/test/unit/blocklist-adapter.spec.ts
@@ -1,0 +1,65 @@
+import { IConfigComponent, IFetchComponent, Response } from '@well-known-components/interfaces'
+import { createBlockListComponent, IBlockListComponent } from '../../src/adapters/blocklist'
+
+let blockList: IBlockListComponent
+let config: IConfigComponent
+let fetch: IFetchComponent
+let fetchMock: jest.MockedFunction<typeof fetch.fetch>
+
+beforeEach(async () => {
+  fetchMock = jest.fn()
+  config = {
+    requireString: jest.fn().mockResolvedValue('https://example.com/blacklist.json'),
+    getString: jest.fn(),
+    getNumber: jest.fn(),
+    requireNumber: jest.fn()
+  }
+  fetch = {
+    fetch: fetchMock
+  }
+  blockList = await createBlockListComponent({ config, fetch })
+})
+
+describe('when checking if a wallet is blacklisted', () => {
+  describe('and fetching the blacklist fails', () => {
+    beforeEach(() => {
+      fetchMock.mockRejectedValueOnce(new Error('Network error'))
+    })
+
+    it('should reject, propagating the error', async () => {
+      await expect(blockList.isBlacklisted('0x123')).rejects.toThrow('Network error')
+    })
+  })
+
+  describe('and fetching the blacklist results in a non-200 status', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce({ ok: false, status: 404 } as Response)
+    })
+
+    it('should reject with an error saying that the deny list could not be fetched', async () => {
+      await expect(blockList.isBlacklisted('0x123')).rejects.toThrow('Failed to fetch deny list, status: 404')
+    })
+  })
+
+  describe('and the wallet is not in the blacklist', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ users: [] }) } as Response)
+    })
+
+    it('should resolve to false', async () => {
+      const isBlacklisted = await blockList.isBlacklisted('0x123')
+      expect(isBlacklisted).toBe(false)
+    })
+  })
+
+  describe('and the wallet is in the blacklist', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ users: [{ wallet: '0x123' }] }) } as Response)
+    })
+
+    it('should resolve to true', async () => {
+      const isBlacklisted = await blockList.isBlacklisted('0x123')
+      expect(isBlacklisted).toBe(true)
+    })
+  })
+})

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -1,4 +1,4 @@
-import { validateFilters, ensureSlashAtTheEnd, fetchBlacklistedWallets } from '../../src/controllers/handlers/utils'
+import { validateFilters, ensureSlashAtTheEnd } from '../../src/controllers/handlers/utils'
 
 describe('ensureSlashAtTheEnd', () => {
   it('should add a trailing slash if not present', () => {
@@ -37,74 +37,5 @@ describe('validateFilters', () => {
     const result = validateFilters({ admin: 123 as any })
     expect(result.valid).toBe(false)
     expect(result.error).toBe('admin must be a string')
-  })
-})
-
-describe('fetchBlacklistedWallets', () => {
-  let originalFetch: any
-
-  beforeEach(() => {
-    originalFetch = global.fetch
-    global.fetch = jest.fn()
-  })
-
-  afterEach(() => {
-    global.fetch = originalFetch
-  })
-
-  it('should return a set of blacklisted wallets', async () => {
-    const mockResponse = {
-      ok: true,
-      json: jest.fn().mockResolvedValue({
-        users: [{ wallet: '0x123' }, { wallet: '0xABC' }]
-      })
-    }
-
-    global.fetch = jest.fn().mockResolvedValue(mockResponse)
-
-    const result = await fetchBlacklistedWallets('https://example.com/blacklist.json')
-
-    expect(result).toBeInstanceOf(Set)
-    expect(result.has('0x123')).toBe(true)
-    expect(result.has('0xabc')).toBe(true)
-    expect(result.size).toBe(2)
-  })
-
-  it('should handle fetch errors', async () => {
-    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
-
-    global.fetch = jest.fn().mockRejectedValue(new Error('Network error'))
-
-    let error: Error | null = null
-    try {
-      await fetchBlacklistedWallets('https://example.com/blacklist.json')
-    } catch (e) {
-      error = e as Error
-    }
-
-    expect(error).not.toBeNull()
-    expect(error?.message).toContain('Network error')
-
-    consoleErrorSpy.mockRestore()
-  })
-
-  it('should handle invalid response format', async () => {
-    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
-
-    const mockResponse = {
-      ok: true,
-      json: jest.fn().mockResolvedValue({
-        notUsers: []
-      })
-    }
-
-    global.fetch = jest.fn().mockResolvedValue(mockResponse)
-
-    const result = await fetchBlacklistedWallets('https://example.com/blacklist.json')
-
-    expect(result).toBeInstanceOf(Set)
-    expect(result.size).toBe(0)
-
-    consoleWarnSpy.mockRestore()
   })
 })


### PR DESCRIPTION
This PR componenterizes the blocklist functionality so it can be used in other routes, tested and eventually, when the tracing is merged, perform a fetch with the trace id.