### PR TITLE
fix: Livekit host protocol

### DIFF
--- a/src/adapters/livekit.ts
+++ b/src/adapters/livekit.ts
@@ -68,7 +68,7 @@ export async function createLivekitComponent(
     })
 
     return {
-      url: `wss://${settings.host}`,
+      url: settings.host,
       token: token.toJwt()
     }
   }


### PR DESCRIPTION
This PR changes the livekit component to return the host without adding the protocol, which now comes in the environment variable set in the definitions.