### PR TITLE
feat: add places checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@well-known-components/metrics": "^2.0.1-20220909150423.commit-8f7e5bc",
     "@well-known-components/pg-component": "^1.1.0",
     "@well-known-components/tracer-component": "^1.2.0",
+    "cron": "^4.1.3",
     "livekit-server-sdk": "^1.2.7",
     "lru-cache": "^10.1.0",
     "sql-template-strings": "^2.2.2"

--- a/src/adapters/places-checker.ts
+++ b/src/adapters/places-checker.ts
@@ -1,0 +1,65 @@
+import { AppComponents } from '../types'
+import { IPlaceChecker } from '../types/places-checker.type'
+import { CronJob } from 'cron'
+
+export async function createPlaceChecker(
+  components: Pick<AppComponents, 'logs' | 'sceneAdminManager' | 'sceneStreamAccessManager' | 'places'>
+): Promise<IPlaceChecker> {
+  const { logs, sceneAdminManager, sceneStreamAccessManager, places } = components
+  const logger = logs.getLogger(`mission-checker`)
+  let job: CronJob
+  async function start(): Promise<void> {
+    job = new CronJob(
+      '0 0 0 * * 1', // Every monday at 00:00
+      async function () {
+        try {
+          logger.info(`Looking into active places.`)
+
+          const placesIdWithActiveAdmins = await sceneAdminManager.getPlacesIdWithActiveAdmins()
+          if (placesIdWithActiveAdmins.length === 0) {
+            logger.info(`No places with active admins found.`)
+            return
+          }
+
+          const placesFromIds = await places.getPlaceByIds(placesIdWithActiveAdmins)
+
+          const placesDisabled = placesFromIds.filter((place) => place.disabled)
+
+          if (placesDisabled.length > 0) {
+            logger.info(`Places disabled found: ${placesDisabled.map((place) => place.id).join(', ')}`)
+            return
+          }
+
+          await Promise.all([
+            ...placesFromIds.map(async (place) => {
+              await sceneAdminManager.removeAllAdminsByPlaceId(place.id)
+            }),
+            ...placesFromIds.map(async (place) => {
+              await sceneStreamAccessManager.removeAccess(place.id)
+            })
+          ])
+
+          logger.info(
+            `All admins and stream access removed for places: ${placesFromIds.map((place) => place.id).join(', ')}`
+          )
+          return
+        } catch (error) {
+          logger.warn(`Error while checking places: ${error}`)
+        }
+      },
+      null,
+      false,
+      'UCT'
+    )
+    job.start()
+  }
+
+  async function stop() {
+    job?.stop()
+  }
+
+  return {
+    start,
+    stop
+  }
+}

--- a/src/adapters/places-checker.ts
+++ b/src/adapters/places-checker.ts
@@ -21,7 +21,7 @@ export async function createPlaceChecker(
             return
           }
 
-          const placesFromIds = await places.getPlaceByIds(placesIdWithActiveAdmins)
+          const placesFromIds = await places.getPlaceStateById(placesIdWithActiveAdmins)
 
           const placesDisabled = placesFromIds.filter((place) => place.disabled)
 

--- a/src/adapters/places-checker.ts
+++ b/src/adapters/places-checker.ts
@@ -23,17 +23,11 @@ export async function createPlaceChecker(
 
           let placesFromIds: Array<{ id: string; disabled: boolean }> = []
           const batchSize = 100
-          const delayBetweenBatches = 60000 // one minute
 
           for (let i = 0; i < placesIdWithActiveAdmins.length; i += batchSize) {
             const batch = placesIdWithActiveAdmins.slice(i, i + batchSize)
             const batchResult = await places.getPlaceStatusById(batch)
             placesFromIds = placesFromIds.concat(batchResult)
-
-            // Add delay between batches, except for the last batch
-            if (i + batchSize < placesIdWithActiveAdmins.length) {
-              await new Promise((resolve) => setTimeout(resolve, delayBetweenBatches))
-            }
           }
 
           const placesDisabled = placesFromIds.filter((place) => place.disabled)

--- a/src/adapters/places.ts
+++ b/src/adapters/places.ts
@@ -34,8 +34,8 @@ export async function createPlacesComponent(
     return response.data[0]
   }
 
-  async function getPlaceByIds(ids: string[]): Promise<PlaceAttributes[]> {
-    const response = await fetch.fetch(`${placesApiUrl}/places`, {
+  async function getPlaceStateById(ids: string[]): Promise<Pick<PlaceAttributes, 'id' | 'disabled'>[]> {
+    const response = await fetch.fetch(`${placesApiUrl}/places/status`, {
       method: 'POST',
       body: JSON.stringify(ids)
     })
@@ -53,6 +53,6 @@ export async function createPlacesComponent(
   return {
     getPlaceByParcel,
     getPlaceByWorldName,
-    getPlaceByIds
+    getPlaceStateById
   }
 }

--- a/src/adapters/places.ts
+++ b/src/adapters/places.ts
@@ -34,7 +34,7 @@ export async function createPlacesComponent(
     return response.data[0]
   }
 
-  async function getPlaceStateById(ids: string[]): Promise<Pick<PlaceAttributes, 'id' | 'disabled'>[]> {
+  async function getPlaceStatusById(ids: string[]): Promise<Pick<PlaceAttributes, 'id' | 'disabled'>[]> {
     const response = await fetch.fetch(`${placesApiUrl}/places/status`, {
       method: 'POST',
       body: JSON.stringify(ids)
@@ -53,6 +53,6 @@ export async function createPlacesComponent(
   return {
     getPlaceByParcel,
     getPlaceByWorldName,
-    getPlaceStateById
+    getPlaceStatusById
   }
 }

--- a/src/adapters/scene-admin-manager.ts
+++ b/src/adapters/scene-admin-manager.ts
@@ -117,10 +117,33 @@ export async function createSceneAdminManagerComponent({
     return result.rows
   }
 
+  async function getPlacesIdWithActiveAdmins(): Promise<string[]> {
+    const query = SQL`
+      SELECT DISTINCT place_id FROM scene_admin 
+      WHERE active = true`
+
+    const result = await database.query<SceneAdmin>(query)
+
+    return result.rows.map((row) => row.place_id)
+  }
+
+  async function removeAllAdminsByPlaceId(placeId: string): Promise<void> {
+    await database.query(
+      SQL`UPDATE scene_admin 
+          SET active = false
+          WHERE place_id = ${placeId} 
+          AND active = true`
+    )
+
+    logger.info(`All admins deactivated for place ${placeId}`)
+  }
+
   return {
     addAdmin,
     removeAdmin,
     listActiveAdmins,
-    isAdmin
+    isAdmin,
+    getPlacesIdWithActiveAdmins,
+    removeAllAdminsByPlaceId
   }
 }

--- a/src/adapters/scene-admin-manager.ts
+++ b/src/adapters/scene-admin-manager.ts
@@ -127,15 +127,16 @@ export async function createSceneAdminManagerComponent({
     return result.rows.map((row) => row.place_id)
   }
 
-  async function removeAllAdminsByPlaceId(placeId: string): Promise<void> {
-    await database.query(
-      SQL`UPDATE scene_admin 
-          SET active = false
-          WHERE place_id = ${placeId} 
-          AND active = true`
-    )
+  async function removeAllAdminsByPlaceIds(placeIds: string[]): Promise<void> {
+    const query = SQL`
+      UPDATE scene_admin 
+      SET active = false
+      WHERE place_id = ANY(${placeIds})
+      AND active = true`
 
-    logger.info(`All admins deactivated for place ${placeId}`)
+    await database.query(query)
+
+    logger.info(`All admins deactivated for places ${placeIds.join(', ')}`)
   }
 
   return {
@@ -144,6 +145,6 @@ export async function createSceneAdminManagerComponent({
     listActiveAdmins,
     isAdmin,
     getPlacesIdWithActiveAdmins,
-    removeAllAdminsByPlaceId
+    removeAllAdminsByPlaceIds
   }
 }

--- a/src/adapters/scene-stream-access-manager.ts
+++ b/src/adapters/scene-stream-access-manager.ts
@@ -40,6 +40,18 @@ export async function createSceneStreamAccessManagerComponent({
     )
   }
 
+  async function removeAccessByPlaceIds(placeIds: string[]): Promise<void> {
+    logger.debug('Removing stream access', { placeIds: placeIds.join(', ') })
+
+    const query = SQL`
+      UPDATE scene_stream_access 
+      SET active = false 
+      WHERE place_id = ANY(${placeIds})
+      AND active = true`
+
+    await database.query(query)
+  }
+
   async function getAccess(placeId: string): Promise<SceneStreamAccess> {
     logger.debug('Getting stream access', { placeId })
 
@@ -60,6 +72,7 @@ export async function createSceneStreamAccessManagerComponent({
   return {
     addAccess,
     removeAccess,
+    removeAccessByPlaceIds,
     getAccess
   }
 }

--- a/src/components.ts
+++ b/src/components.ts
@@ -20,6 +20,7 @@ import { createPlacesComponent } from './adapters/places'
 import { createLandsComponent } from './adapters/lands'
 import { createSceneManagerComponent } from './adapters/scene-manager'
 import { createNamesComponent } from './adapters/names'
+import { createPlaceChecker } from './adapters/places-checker'
 
 // Initialize all the components of the app
 export async function initComponents(): Promise<AppComponents> {
@@ -72,12 +73,19 @@ export async function initComponents(): Promise<AppComponents> {
 
   const cachedFetch = await cachedFetchComponent({ fetch: tracedFetch, logs })
   const worlds = await createWorldsComponent({ config, logs, cachedFetch })
-  const places = await createPlacesComponent({ config, logs, cachedFetch })
+  const places = await createPlacesComponent({ config, logs, cachedFetch, fetch: tracedFetch })
   const lands = await createLandsComponent({ config, logs, cachedFetch })
   const names = await createNamesComponent({ config, logs, fetch: tracedFetch })
   const sceneManager = await createSceneManagerComponent({ worlds, lands, sceneAdminManager })
 
   const sceneStreamAccessManager = await createSceneStreamAccessManagerComponent({ database, logs })
+
+  const placesChecker = await createPlaceChecker({
+    logs,
+    sceneAdminManager,
+    sceneStreamAccessManager,
+    places
+  })
 
   return {
     blockList,
@@ -97,6 +105,7 @@ export async function initComponents(): Promise<AppComponents> {
     livekit,
     database,
     sceneAdminManager,
-    sceneStreamAccessManager
+    sceneStreamAccessManager,
+    placesChecker
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ import { IWorldComponent } from './types/worlds.type'
 import { ILandComponent } from './types/lands.type'
 import { ISceneManager } from './types/scene-manager.type'
 import { INamesComponent } from './types/names.type'
+import { IPlaceChecker } from './types/places-checker.type'
 
 export type GlobalContext = {
   components: BaseComponents
@@ -42,6 +43,7 @@ export type BaseComponents = {
   lands: ILandComponent
   names: INamesComponent
   sceneManager: ISceneManager
+  placesChecker: IPlaceChecker
 }
 
 export type AppComponents = BaseComponents & {
@@ -162,6 +164,8 @@ export interface ISceneAdminManager {
   removeAdmin(placeId: string, adminAddress: string): Promise<void>
   listActiveAdmins(filters: ListSceneAdminFilters): Promise<SceneAdmin[]>
   isAdmin(placeId: string, address: string): Promise<boolean>
+  getPlacesIdWithActiveAdmins(): Promise<string[]>
+  removeAllAdminsByPlaceId(placeId: string): Promise<void>
 }
 
 export interface ISceneStreamAccessManager {

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,12 +165,13 @@ export interface ISceneAdminManager {
   listActiveAdmins(filters: ListSceneAdminFilters): Promise<SceneAdmin[]>
   isAdmin(placeId: string, address: string): Promise<boolean>
   getPlacesIdWithActiveAdmins(): Promise<string[]>
-  removeAllAdminsByPlaceId(placeId: string): Promise<void>
+  removeAllAdminsByPlaceIds(placeIds: string[]): Promise<void>
 }
 
 export interface ISceneStreamAccessManager {
   addAccess(input: AddSceneStreamAccessInput): Promise<SceneStreamAccess>
   removeAccess(placeId: string): Promise<void>
+  removeAccessByPlaceIds(placeIds: string[]): Promise<void>
   getAccess(placeId: string): Promise<SceneStreamAccess>
 }
 

--- a/src/types/places-checker.type.ts
+++ b/src/types/places-checker.type.ts
@@ -1,0 +1,3 @@
+import { IBaseComponent } from '@well-known-components/interfaces'
+
+export type IPlaceChecker = IBaseComponent

--- a/src/types/places.type.ts
+++ b/src/types/places.type.ts
@@ -3,7 +3,7 @@ import { IBaseComponent } from '@well-known-components/interfaces'
 export type IPlacesComponent = IBaseComponent & {
   getPlaceByParcel(parcel: string): Promise<PlaceAttributes>
   getPlaceByWorldName(worldName: string): Promise<PlaceAttributes>
-  getPlaceByIds(ids: string[]): Promise<PlaceAttributes[]>
+  getPlaceStateById(ids: string[]): Promise<Pick<PlaceAttributes, 'id' | 'disabled'>[]>
 }
 
 export type PlaceAttributes = {

--- a/src/types/places.type.ts
+++ b/src/types/places.type.ts
@@ -3,7 +3,7 @@ import { IBaseComponent } from '@well-known-components/interfaces'
 export type IPlacesComponent = IBaseComponent & {
   getPlaceByParcel(parcel: string): Promise<PlaceAttributes>
   getPlaceByWorldName(worldName: string): Promise<PlaceAttributes>
-  getPlaceStateById(ids: string[]): Promise<Pick<PlaceAttributes, 'id' | 'disabled'>[]>
+  getPlaceStatusById(ids: string[]): Promise<Pick<PlaceAttributes, 'id' | 'disabled'>[]>
 }
 
 export type PlaceAttributes = {

--- a/src/types/places.type.ts
+++ b/src/types/places.type.ts
@@ -3,6 +3,7 @@ import { IBaseComponent } from '@well-known-components/interfaces'
 export type IPlacesComponent = IBaseComponent & {
   getPlaceByParcel(parcel: string): Promise<PlaceAttributes>
   getPlaceByWorldName(worldName: string): Promise<PlaceAttributes>
+  getPlaceByIds(ids: string[]): Promise<PlaceAttributes[]>
 }
 
 export type PlaceAttributes = {

--- a/test/integration/places-component.spec.ts
+++ b/test/integration/places-component.spec.ts
@@ -9,6 +9,7 @@ describe('PlacesComponent', () => {
     jest.clearAllMocks()
 
     mockFetch = jest.fn()
+    const mockFetchComponent = { fetch: mockFetch }
 
     const mockConfig = {
       requireString: jest.fn().mockImplementation((key) => {
@@ -40,7 +41,8 @@ describe('PlacesComponent', () => {
     placesComponent = await createPlacesComponent({
       config: mockConfig,
       cachedFetch: mockCachedFetch,
-      logs: mockLogs
+      logs: mockLogs,
+      fetch: mockFetchComponent
     })
   })
 

--- a/test/integration/places-component.spec.ts
+++ b/test/integration/places-component.spec.ts
@@ -108,4 +108,48 @@ describe('PlacesComponent', () => {
       expect(mockFetch).toHaveBeenCalledWith('https://places.decentraland.org/api/worlds?names=nonexistent-world')
     })
   })
+
+  describe('getPlaceStatusById', () => {
+    it('should return place statuses for given ids', async () => {
+      const mockResponse = {
+        data: [
+          { id: '1', disabled: false },
+          { id: '2', disabled: true }
+        ]
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        json: () => Promise.resolve(mockResponse)
+      })
+
+      const result = await placesComponent.getPlaceStatusById(['1', '2'])
+
+      expect(mockFetch).toHaveBeenCalledWith('https://places.decentraland.org/api/places/status', {
+        method: 'POST',
+        body: JSON.stringify(['1', '2'])
+      })
+
+      expect(result).toEqual([
+        { id: '1', disabled: false },
+        { id: '2', disabled: true }
+      ])
+    })
+
+    it('should throw PlaceNotFoundError when no places are found', async () => {
+      const mockResponse = {
+        data: []
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        json: () => Promise.resolve(mockResponse)
+      })
+
+      await expect(placesComponent.getPlaceStatusById(['1', '2'])).rejects.toThrow(PlaceNotFoundError)
+
+      expect(mockFetch).toHaveBeenCalledWith('https://places.decentraland.org/api/places/status', {
+        method: 'POST',
+        body: JSON.stringify(['1', '2'])
+      })
+    })
+  })
 })

--- a/test/integration/scene-admin/remove-scene-admin-handler.spec.ts
+++ b/test/integration/scene-admin/remove-scene-admin-handler.spec.ts
@@ -43,6 +43,12 @@ test('DELETE /scene-admin - removes administrator access for a scene', ({ compon
       added_by: ownerAddress
     })
 
+    await sceneAdminManager.addAdmin({
+      place_id: placeId,
+      admin: otherAdminAddress,
+      added_by: ownerAddress
+    })
+
     try {
       const adminResults = await sceneAdminManager.listActiveAdmins({
         place_id: placeId
@@ -58,12 +64,6 @@ test('DELETE /scene-admin - removes administrator access for a scene', ({ compon
     } catch (error) {
       console.error('Error listing admins:', error)
     }
-
-    await sceneAdminManager.addAdmin({
-      place_id: placeId,
-      admin: otherAdminAddress,
-      added_by: ownerAddress
-    })
 
     metadataLand = {
       identity: ownerAddress,

--- a/test/integration/scene-manager-component.spec.ts
+++ b/test/integration/scene-manager-component.spec.ts
@@ -3,7 +3,7 @@ import { createSceneManagerComponent } from '../../src/adapters/scene-manager'
 import { PlaceAttributes } from '../../src/types/places.type'
 import { ISceneManager } from '../../src/types/scene-manager.type'
 
-test('SceneManagerComponent', ({ components, stubComponents }) => {
+test('SceneManagerComponent', ({ stubComponents }) => {
   const testPlaceId = `place-id-test`
   const testAddress = '0x123'
   const testParcel = '10,20'

--- a/test/unit/places-checker.spec.ts
+++ b/test/unit/places-checker.spec.ts
@@ -1,0 +1,125 @@
+import { createPlaceChecker } from '../../src/adapters/places-checker'
+import { CronJob, CronOnCompleteCommand } from 'cron'
+import { IPlaceChecker } from '../../src/types/places-checker.type'
+import { IBaseComponent } from '@well-known-components/interfaces'
+
+jest.mock('cron', () => ({
+  CronJob: jest.fn().mockImplementation((cronTime, onTick, onComplete, start, timeZone) => {
+    return {
+      start: jest.fn(),
+      stop: jest.fn()
+    }
+  })
+}))
+
+const MockedCronJob = CronJob as jest.MockedClass<typeof CronJob>
+
+describe('PlaceChecker', () => {
+  let placeChecker: IPlaceChecker & IBaseComponent
+  let mockedComponents: any
+  let startOptions: IBaseComponent.ComponentStartOptions
+
+  beforeEach(async () => {
+    MockedCronJob.mockClear()
+
+    mockedComponents = {
+      logs: {
+        getLogger: jest.fn().mockReturnValue({
+          info: jest.fn(),
+          error: jest.fn()
+        })
+      },
+      sceneAdminManager: {
+        getPlacesIdWithActiveAdmins: jest.fn(),
+        removeAllAdminsByPlaceIds: jest.fn()
+      },
+      sceneStreamAccessManager: {
+        removeAccessByPlaceIds: jest.fn()
+      },
+      places: {
+        getPlaceStatusById: jest.fn()
+      }
+    }
+
+    startOptions = {
+      started: () => true,
+      live: () => true,
+      getComponents: () => mockedComponents
+    }
+
+    placeChecker = await createPlaceChecker(mockedComponents)
+  })
+
+  describe('start', () => {
+    it('should start the cron job', async () => {
+      await placeChecker.start(startOptions)
+      const mockJobInstance = MockedCronJob.mock.results[0]?.value
+      expect(MockedCronJob).toHaveBeenCalled()
+      expect(mockJobInstance?.start).toHaveBeenCalled()
+    })
+
+    it('should handle no places with active admins', async () => {
+      mockedComponents.sceneAdminManager.getPlacesIdWithActiveAdmins.mockResolvedValue([])
+      await placeChecker.start(startOptions)
+      const constructorArgs = MockedCronJob.mock.calls[0]
+      const onTickFunction = constructorArgs[1] as (() => void | Promise<void>) | undefined
+      if (typeof onTickFunction === 'function') {
+        await onTickFunction()
+      } else {
+        throw new Error('onTick function was not passed to CronJob constructor mock')
+      }
+      expect(mockedComponents.logs.getLogger().info).toHaveBeenCalledWith('No places with active admins found.')
+    })
+
+    it('should handle places with active admins', async () => {
+      const mockPlaces = ['place1', 'place2']
+      const mockPlaceStatus = [
+        { id: 'place1', disabled: false },
+        { id: 'place2', disabled: true }
+      ]
+
+      mockedComponents.sceneAdminManager.getPlacesIdWithActiveAdmins.mockResolvedValue(mockPlaces)
+      mockedComponents.places.getPlaceStatusById.mockResolvedValue(mockPlaceStatus)
+
+      await placeChecker.start(startOptions)
+      const constructorArgs = MockedCronJob.mock.calls[0]
+      const onTickFunction = constructorArgs[1] as (() => void | Promise<void>) | undefined
+      if (typeof onTickFunction === 'function') {
+        await onTickFunction()
+      } else {
+        throw new Error('onTick function was not passed to CronJob constructor mock')
+      }
+
+      expect(mockedComponents.sceneAdminManager.removeAllAdminsByPlaceIds).toHaveBeenCalledWith(['place2'])
+      expect(mockedComponents.sceneStreamAccessManager.removeAccessByPlaceIds).toHaveBeenCalledWith(['place2'])
+      expect(mockedComponents.logs.getLogger().info).toHaveBeenCalledWith(
+        'All admins and stream access removed for places: place2'
+      )
+    })
+
+    it('should handle errors gracefully', async () => {
+      const error = new Error('Test error')
+      mockedComponents.sceneAdminManager.getPlacesIdWithActiveAdmins.mockRejectedValue(error)
+
+      await placeChecker.start(startOptions)
+      const constructorArgs = MockedCronJob.mock.calls[0]
+      const onTickFunction = constructorArgs[1] as (() => void | Promise<void>) | undefined
+      if (typeof onTickFunction === 'function') {
+        await onTickFunction()
+      } else {
+        throw new Error('onTick function was not passed to CronJob constructor mock')
+      }
+
+      expect(mockedComponents.logs.getLogger().error).toHaveBeenCalledWith(`Error while checking places: ${error}`)
+    })
+  })
+
+  describe('stop', () => {
+    it('should stop the cron job', async () => {
+      await placeChecker.start(startOptions)
+      const mockJobInstance = MockedCronJob.mock.results[0]?.value
+      await placeChecker.stop()
+      expect(mockJobInstance?.stop).toHaveBeenCalled()
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -926,6 +926,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
+"@types/luxon@~3.4.0":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.4.2.tgz#e4fc7214a420173cea47739c33cdf10874694db7"
+  integrity sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==
+
 "@types/node-fetch@^2.5.12":
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.9.tgz#15f529d247f1ede1824f7e7acdaa192d5f28071e"
@@ -1601,6 +1606,14 @@ create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
+cron@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/cron/-/cron-4.1.3.tgz#42661cebdf15483f90f63e799c9dbd33a298265c"
+  integrity sha512-HETm5kgivcdfboOmBIzq0cfC9c5bRilWZ1p7PWwnOMmbWviwIU6mPgZbeqbj5i0AzNan6P68WDTDEDezhKjOng==
+  dependencies:
+    "@types/luxon" "~3.4.0"
+    luxon "~3.6.0"
 
 cross-fetch@^3.1.5:
   version "3.1.8"
@@ -2994,6 +3007,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+luxon@~3.6.0:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.6.1.tgz#d283ffc4c0076cb0db7885ec6da1c49ba97e47b0"
+  integrity sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==
 
 make-dir@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Changes Overview
This PR introduces a new feature to automatically check and manage disabled places. The main changes include:

### New Features
- Added a new `PlaceChecker` component that runs periodically (once a week) to check the status of places with active admins
- Implemented functionality to automatically remove admin access and stream access for disabled places
- Added new endpoints and methods to support place status checking and bulk operations

## Technical Details
- The checker runs every minute (configurable via cron expression)
- Uses batch processing for handling multiple places efficiently
- Implements proper error handling and logging throughout the process

## Impact
This change improves the system's ability to automatically manage access rights for disabled places, reducing manual intervention and potential security risks.
