### PR TITLE
feat: add owner and operators in list admins

### DIFF
--- a/src/adapters/lands.ts
+++ b/src/adapters/lands.ts
@@ -17,7 +17,7 @@ export async function createLandsComponent(
   ): Promise<LandsParcelPermissionsResponse> {
     const baseUrl = ensureSlashAtTheEnd(lambdasUrl)
     if (!baseUrl) {
-      logger.info('Lambdas URL is not set')
+      logger.error('Lambdas URL is not set')
       throw new Error('Lambdas URL is not set')
     }
 
@@ -39,7 +39,7 @@ export async function createLandsComponent(
   async function getLandOperators(parcel: string): Promise<LandsParcelOperatorsResponse> {
     const baseUrl = ensureSlashAtTheEnd(lambdasUrl)
     if (!baseUrl) {
-      logger.info('Lambdas URL is not set')
+      logger.error('Lambdas URL is not set')
       throw new Error('Lambdas URL is not set')
     }
     const [x, y] = parcel.split(',')

--- a/src/adapters/lands.ts
+++ b/src/adapters/lands.ts
@@ -1,7 +1,7 @@
 import { ensureSlashAtTheEnd } from '../logic/utils'
 import { AppComponents } from '../types'
 import { LandPermissionsNotFoundError } from '../types/errors'
-import { ILandComponent, LandsParcelPermissionsResponse } from '../types/lands.type'
+import { ILandComponent, LandsParcelOperatorsResponse, LandsParcelPermissionsResponse } from '../types/lands.type'
 
 export async function createLandsComponent(
   components: Pick<AppComponents, 'config' | 'cachedFetch' | 'logs'>
@@ -36,7 +36,27 @@ export async function createLandsComponent(
     return parcelPermissionsResponse
   }
 
+  async function getLandOperators(parcel: string): Promise<LandsParcelOperatorsResponse> {
+    const baseUrl = ensureSlashAtTheEnd(lambdasUrl)
+    if (!baseUrl) {
+      logger.info('Lambdas URL is not set')
+      throw new Error('Lambdas URL is not set')
+    }
+    const [x, y] = parcel.split(',')
+    const parcelPermissionsResponse = await cachedFetch
+      .cache<LandsParcelOperatorsResponse>()
+      .fetch(`${baseUrl}parcels/${x}/${y}/operators`)
+
+    if (!parcelPermissionsResponse) {
+      logger.info(`Land permissions not found for ${x},${y}`)
+      throw new LandPermissionsNotFoundError(`Land permissions not found for ${x},${y}`)
+    }
+
+    return parcelPermissionsResponse
+  }
+
   return {
-    getLandUpdatePermission
+    getLandUpdatePermission,
+    getLandOperators
   }
 }

--- a/src/adapters/names.ts
+++ b/src/adapters/names.ts
@@ -15,7 +15,7 @@ export async function createNamesComponent(
   async function getNamesFromAddresses(addresses: string[]): Promise<Record<string, string>> {
     const baseUrl = ensureSlashAtTheEnd(lambdasUrl)
     if (!baseUrl) {
-      logger.info('Lambdas URL is not set')
+      logger.error('Lambdas URL is not set')
       throw new Error('Lambdas URL is not set')
     }
 

--- a/src/controllers/handlers/scene-admin-handlers/list-scene-admins-handler.ts
+++ b/src/controllers/handlers/scene-admin-handlers/list-scene-admins-handler.ts
@@ -4,18 +4,19 @@ import { InvalidRequestError, UnauthorizedError } from '../../../types/errors'
 import { validate, validateFilters } from '../../../logic/utils'
 import { PlaceAttributes } from '../../../types/places.type'
 import { PermissionsOverWorld, PermissionType } from '../../../types/worlds.type'
+import { LandsParcelOperatorsResponse } from '../../../types/lands.type'
 
 export async function listSceneAdminsHandler(
   ctx: Pick<
     HandlerContextWithPath<
-      'sceneAdminManager' | 'logs' | 'config' | 'fetch' | 'sceneManager' | 'places' | 'names' | 'worlds',
+      'sceneAdminManager' | 'logs' | 'config' | 'fetch' | 'sceneManager' | 'places' | 'names' | 'worlds' | 'lands',
       '/scene-admin'
     >,
     'components' | 'url' | 'verification' | 'request' | 'params'
   >
 ): Promise<IHttpServerComponent.IResponse> {
   const {
-    components: { logs, sceneAdminManager, sceneManager, places, names, worlds },
+    components: { logs, sceneAdminManager, sceneManager, places, names, worlds, lands },
     url,
     verification
   } = ctx
@@ -24,6 +25,7 @@ export async function listSceneAdminsHandler(
   const { getPlaceByWorldName, getPlaceByParcel } = places
   const { isSceneOwnerOrAdmin } = sceneManager
   const { fetchWorldActionPermissions } = worlds
+  const { getLandOperators } = lands
 
   if (!verification || verification?.auth === undefined) {
     logger.warn('Request without authentication')
@@ -75,8 +77,15 @@ export async function listSceneAdminsHandler(
 
   const extraAddresses = new Set<string>()
   let worldActionPermissions: PermissionsOverWorld | undefined
+  let landActionPermissions: LandsParcelOperatorsResponse | undefined
 
   isWorlds && (worldActionPermissions = await fetchWorldActionPermissions(place.world_name!))
+  !isWorlds && (landActionPermissions = await getLandOperators(parcel))
+
+  if (landActionPermissions) {
+    extraAddresses.add(landActionPermissions.owner.toLowerCase())
+    landActionPermissions.operator && extraAddresses.add(landActionPermissions.operator.toLowerCase())
+  }
 
   if (worldActionPermissions?.permissions.deployment.type === PermissionType.AllowList) {
     worldActionPermissions.permissions.deployment.wallets.forEach((wallet) => extraAddresses.add(wallet.toLowerCase()))

--- a/src/controllers/handlers/scene-admin-handlers/list-scene-admins-handler.ts
+++ b/src/controllers/handlers/scene-admin-handlers/list-scene-admins-handler.ts
@@ -79,8 +79,11 @@ export async function listSceneAdminsHandler(
   let worldActionPermissions: PermissionsOverWorld | undefined
   let landActionPermissions: LandsParcelOperatorsResponse | undefined
 
-  isWorlds && (worldActionPermissions = await fetchWorldActionPermissions(place.world_name!))
-  !isWorlds && (landActionPermissions = await getLandOperators(parcel))
+  if (isWorlds) {
+    worldActionPermissions = await fetchWorldActionPermissions(place.world_name!)
+  } else {
+    landActionPermissions = await getLandOperators(parcel)
+  }
 
   if (landActionPermissions) {
     extraAddresses.add(landActionPermissions.owner.toLowerCase())

--- a/src/types/lands.type.ts
+++ b/src/types/lands.type.ts
@@ -5,6 +5,12 @@ export type LandsParcelPermissionsResponse = {
   owner: boolean
 }
 
+export type LandsParcelOperatorsResponse = {
+  owner: string
+  operator?: string
+}
+
 export type ILandComponent = IBaseComponent & {
   getLandUpdatePermission(authAddress: string, placePositions: string[]): Promise<LandsParcelPermissionsResponse>
+  getLandOperators(parcel: string): Promise<LandsParcelOperatorsResponse>
 }

--- a/test/integration/land-component.spec.ts
+++ b/test/integration/land-component.spec.ts
@@ -1,5 +1,5 @@
 import { createLandsComponent } from '../../src/adapters/lands'
-import { LandsParcelPermissionsResponse } from '../../src/types/lands.type'
+import { LandsParcelPermissionsResponse, LandsParcelOperatorsResponse } from '../../src/types/lands.type'
 
 describe('LandsComponent', () => {
   let landsComponent: Awaited<ReturnType<typeof createLandsComponent>>
@@ -113,6 +113,67 @@ describe('LandsComponent', () => {
       await expect(component.getLandUpdatePermission('0xUserAddress', ['10,20'])).rejects.toThrow(
         'Lambdas URL is not set'
       )
+    })
+  })
+
+  describe('getLandOperators', () => {
+    it('should return owner and operator when both exist', async () => {
+      const mockParcelOperatorsResponse: LandsParcelOperatorsResponse = {
+        owner: '0xOwnerAddress',
+        operator: '0xOperatorAddress'
+      }
+
+      mockFetch.mockResolvedValueOnce(mockParcelOperatorsResponse)
+
+      const result = await landsComponent.getLandOperators('10,20')
+      expect(result.owner).toBe('0xOwnerAddress')
+      expect(result.operator).toBe('0xOperatorAddress')
+      expect(mockFetch).toHaveBeenCalledWith('https://lambdas.decentraland.org/api/parcels/10/20/operators')
+    })
+
+    it('should return only owner when operator does not exist', async () => {
+      const mockParcelOperatorsResponse: LandsParcelOperatorsResponse = {
+        owner: '0xOwnerAddress'
+      }
+
+      mockFetch.mockResolvedValueOnce(mockParcelOperatorsResponse)
+
+      const result = await landsComponent.getLandOperators('10,20')
+      expect(result.owner).toBe('0xOwnerAddress')
+      expect(result.operator).toBeUndefined()
+      expect(mockFetch).toHaveBeenCalledWith('https://lambdas.decentraland.org/api/parcels/10/20/operators')
+    })
+
+    it('should throw an error when operators response is not available', async () => {
+      mockFetch.mockResolvedValueOnce(null)
+
+      await expect(landsComponent.getLandOperators('10,20')).rejects.toThrow('Land permissions not found for 10,20')
+      expect(mockFetch).toHaveBeenCalledWith('https://lambdas.decentraland.org/api/parcels/10/20/operators')
+    })
+
+    it('should throw an error when lambdas URL is not set', async () => {
+      const mockConfig = {
+        requireString: jest.fn().mockResolvedValue(''),
+        getString: jest.fn(),
+        getNumber: jest.fn(),
+        requireNumber: jest.fn()
+      }
+
+      const component = await createLandsComponent({
+        config: mockConfig,
+        cachedFetch: {
+          cache: jest.fn().mockReturnValue({
+            fetch: jest.fn()
+          })
+        },
+        logs: {
+          getLogger: jest.fn().mockReturnValue({
+            info: jest.fn()
+          })
+        }
+      })
+
+      await expect(component.getLandOperators('10,20')).rejects.toThrow('Lambdas URL is not set')
     })
   })
 })

--- a/test/integration/land-component.spec.ts
+++ b/test/integration/land-component.spec.ts
@@ -105,7 +105,8 @@ describe('LandsComponent', () => {
         },
         logs: {
           getLogger: jest.fn().mockReturnValue({
-            info: jest.fn()
+            info: jest.fn(),
+            error: jest.fn()
           })
         }
       })
@@ -168,7 +169,8 @@ describe('LandsComponent', () => {
         },
         logs: {
           getLogger: jest.fn().mockReturnValue({
-            info: jest.fn()
+            info: jest.fn(),
+            error: jest.fn()
           })
         }
       })

--- a/test/integration/scene-admin/list-scene-admins-handler.spec.ts
+++ b/test/integration/scene-admin/list-scene-admins-handler.spec.ts
@@ -742,4 +742,128 @@ test('GET /scene-admin - lists all active administrators for scenes', ({ compone
     expect(Array.isArray(body)).toBe(true)
     expect(body).toEqual(expectedAdmins)
   })
+
+  it('returns 200 with a list of scene admins including land operators', async () => {
+    const { localFetch } = components
+
+    stubComponents.lands.getLandUpdatePermission.resolves({ owner: true, operator: false })
+    stubComponents.lands.getLandOperators.resolves({
+      owner: '0xOwnerAddress',
+      operator: '0xOperatorAddress'
+    })
+    stubComponents.sceneManager.getUserScenePermissions.resolves({
+      owner: true,
+      admin: false,
+      hasExtendedPermissions: false
+    })
+
+    const response = await makeRequest(
+      localFetch,
+      '/scene-admin',
+      {
+        method: 'GET',
+        metadata: metadataLand
+      },
+      owner
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(Array.isArray(body)).toBe(true)
+    expect(body).toContainEqual({
+      admin: '0xowneraddress',
+      canBeRemoved: false,
+      name: ''
+    })
+    expect(body).toContainEqual({
+      admin: '0xoperatoraddress',
+      canBeRemoved: false,
+      name: ''
+    })
+    expect(stubComponents.lands.getLandOperators.calledOnce).toBe(true)
+  })
+
+  it('returns 200 with a list of scene admins including only land owner when no operator exists', async () => {
+    const { localFetch } = components
+
+    stubComponents.lands.getLandUpdatePermission.resolves({ owner: true, operator: false })
+    stubComponents.lands.getLandOperators.resolves({
+      owner: '0xOwnerAddress'
+    })
+    stubComponents.sceneManager.getUserScenePermissions.resolves({
+      owner: true,
+      admin: false,
+      hasExtendedPermissions: false
+    })
+
+    const response = await makeRequest(
+      localFetch,
+      '/scene-admin',
+      {
+        method: 'GET',
+        metadata: metadataLand
+      },
+      owner
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(Array.isArray(body)).toBe(true)
+    expect(body).toContainEqual({
+      admin: '0xowneraddress',
+      canBeRemoved: false,
+      name: ''
+    })
+    expect(stubComponents.lands.getLandOperators.calledOnce).toBe(true)
+  })
+
+  it('returns 500 when land operators request fails', async () => {
+    const { localFetch } = components
+
+    stubComponents.lands.getLandUpdatePermission.resolves({ owner: true, operator: false })
+    stubComponents.lands.getLandOperators.rejects(new Error('Failed to get land operators'))
+    stubComponents.sceneManager.getUserScenePermissions.resolves({
+      owner: true,
+      admin: false,
+      hasExtendedPermissions: false
+    })
+
+    const response = await makeRequest(
+      localFetch,
+      '/scene-admin',
+      {
+        method: 'GET',
+        metadata: metadataLand
+      },
+      owner
+    )
+
+    expect(response.status).toBe(500)
+    expect(stubComponents.lands.getLandOperators.calledOnce).toBe(true)
+  })
+
+  it('returns 500 when land operators request fails', async () => {
+    const { localFetch } = components
+
+    stubComponents.lands.getLandUpdatePermission.resolves({ owner: true, operator: false })
+    stubComponents.lands.getLandOperators.rejects(new Error('Failed to get land operators'))
+    stubComponents.sceneManager.getUserScenePermissions.resolves({
+      owner: true,
+      admin: false,
+      hasExtendedPermissions: false
+    })
+
+    const response = await makeRequest(
+      localFetch,
+      '/scene-admin',
+      {
+        method: 'GET',
+        metadata: metadataLand
+      },
+      owner
+    )
+
+    expect(response.status).toBe(500)
+    expect(stubComponents.lands.getLandOperators.calledOnce).toBe(true)
+  })
 })

--- a/test/integration/scene-admin/list-scene-admins-handler.spec.ts
+++ b/test/integration/scene-admin/list-scene-admins-handler.spec.ts
@@ -841,29 +841,4 @@ test('GET /scene-admin - lists all active administrators for scenes', ({ compone
     expect(response.status).toBe(500)
     expect(stubComponents.lands.getLandOperators.calledOnce).toBe(true)
   })
-
-  it('returns 500 when land operators request fails', async () => {
-    const { localFetch } = components
-
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: true, operator: false })
-    stubComponents.lands.getLandOperators.rejects(new Error('Failed to get land operators'))
-    stubComponents.sceneManager.getUserScenePermissions.resolves({
-      owner: true,
-      admin: false,
-      hasExtendedPermissions: false
-    })
-
-    const response = await makeRequest(
-      localFetch,
-      '/scene-admin',
-      {
-        method: 'GET',
-        metadata: metadataLand
-      },
-      owner
-    )
-
-    expect(response.status).toBe(500)
-    expect(stubComponents.lands.getLandOperators.calledOnce).toBe(true)
-  })
 })


### PR DESCRIPTION
## Changes
- Added `getLandOperators` functionality to the `lands` component to fetch land owner and operator information
- Modified `listSceneAdminsHandler` to include land operators in the scene admins list

## Technical Details
- The land operators are added to the scene admins list with `canBeRemoved: false`
- Both owner and operator addresses are converted to lowercase for consistency
- The functionality is only triggered for land-based scenes (not worlds)
