### PR TITLE
fix: Change gatekeeper auth token name

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -25,6 +25,7 @@ CATALYST_CONTENT_URL=https://peer.decentraland.org/content
 PLACES_API_URL=https://places.decentraland.org/api
 BLACKLIST_JSON_URL=https://config.decentraland.org/denylist.json
 SOCIAL_SERVICE_URL=https://social-service.decentraland.org
+COMMS_GATEKEEPER_AUTH_TOKEN="aToken"
 WORLD_ROOM_PREFIX=
 SCENE_ROOM_PREFIX=
 PRIVATE_MESSAGES_ROOM_ID=private-messages

--- a/src/controllers/handlers/private-messages/patch-user-metadata-handler.ts
+++ b/src/controllers/handlers/private-messages/patch-user-metadata-handler.ts
@@ -11,7 +11,7 @@ export async function patchUserPrivateMessagesPrivacyHandler(
     components: { livekit, logs, config }
   } = context
 
-  const socialServiceInteractionsToken = await config.requireString('SOCIAL_SERVICE_INTERACTIONS_TOKEN')
+  const socialServiceInteractionsToken = await config.requireString('COMMS_GATEKEEPER_AUTH_TOKEN')
   const PRIVATE_MESSAGES_ROOM_ID = await config.requireString('PRIVATE_MESSAGES_ROOM_ID')
   const logger = logs.getLogger('patch-user-private-message-metadata-handler')
 

--- a/test/integration/private-messages/patch-user-metadata-handler.spec.ts
+++ b/test/integration/private-messages/patch-user-metadata-handler.spec.ts
@@ -14,7 +14,7 @@ test('PATCH /users/:address/private-messages-privacy', ({ components, spyCompone
       private_messages_privacy: PrivateMessagesPrivacy.ALL
     }
     spyComponents.config.requireString.mockImplementation((key) => {
-      if (key === 'SOCIAL_SERVICE_INTERACTIONS_TOKEN') return Promise.resolve(validToken)
+      if (key === 'COMMS_GATEKEEPER_AUTH_TOKEN') return Promise.resolve(validToken)
       if (key === 'PRIVATE_MESSAGES_ROOM_ID') return Promise.resolve('private-messages')
       return Promise.resolve('')
     })


### PR DESCRIPTION
This PR changes the variable used for the auth token to communicate with the Comms Gatekeeper.