### PR TITLE
fix: Wrongly formatted body error in user metadata endpoint

### DIFF
--- a/src/controllers/handlers/private-messages/patch-user-metadata-handler.ts
+++ b/src/controllers/handlers/private-messages/patch-user-metadata-handler.ts
@@ -41,8 +41,8 @@ export async function patchUserPrivateMessagesPrivacyHandler(
 
   // Validate the private_messages_privacy field
   if (
-    body.private_messages_privacy.toLowerCase() !== PrivateMessagesPrivacy.ALL &&
-    body.private_messages_privacy.toLowerCase() !== PrivateMessagesPrivacy.ONLY_FRIENDS
+    body.private_messages_privacy?.toLowerCase() !== PrivateMessagesPrivacy.ALL &&
+    body.private_messages_privacy?.toLowerCase() !== PrivateMessagesPrivacy.ONLY_FRIENDS
   ) {
     throw new InvalidRequestError('Invalid private_messages_privacy')
   }

--- a/test/integration/private-messages/patch-user-metadata-handler.spec.ts
+++ b/test/integration/private-messages/patch-user-metadata-handler.spec.ts
@@ -83,6 +83,21 @@ test('PATCH /users/:address/private-messages-privacy', ({ components, spyCompone
     })
   })
 
+  describe('and the content of the body is a valid JSON without the private_messages_privacy field', () => {
+    it('should respond with a 400 and a message saying that the private_messages_privacy field is required', async () => {
+      const response = await makeRequest(components.localFetch, `/users/${validAddress}/private-messages-privacy`, {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${validToken}`
+        },
+        body: JSON.stringify({})
+      })
+
+      expect(response.status).toBe(400)
+      await expect(response.json()).resolves.toEqual({ error: 'Invalid private_messages_privacy' })
+    })
+  })
+
   describe('when the request is valid', () => {
     describe('and the participant does not exist in the room', () => {
       beforeEach(() => {


### PR DESCRIPTION
Sending a JSON body without the `private_messages_privacy` property to the patch user metadata endpoint caused a 500 error due to `private_messages_privacy` being undefined and being lowercased.