### PR TITLE
break: Use improved Lamb2 API

### DIFF
--- a/src/adapters/lands.ts
+++ b/src/adapters/lands.ts
@@ -11,7 +11,7 @@ export async function createLandsComponent(
 
   const lambdasUrl = await config.requireString('LAMBDAS_URL')
 
-  async function getLandUpdatePermission(
+  async function getLandPermissions(
     authAddress: string,
     placePositions: string[]
   ): Promise<LandsParcelPermissionsResponse> {
@@ -56,7 +56,7 @@ export async function createLandsComponent(
   }
 
   return {
-    getLandUpdatePermission,
+    getLandPermissions,
     getLandOperators
   }
 }

--- a/src/adapters/scene-admins.ts
+++ b/src/adapters/scene-admins.ts
@@ -40,7 +40,10 @@ export async function createSceneAdminsComponent(
 
     if (landActionPermissions) {
       extraAddresses.add(landActionPermissions.owner.toLowerCase())
-      landActionPermissions.operator && extraAddresses.add(landActionPermissions.operator.toLowerCase())
+      landActionPermissions.operators.forEach((operator) => extraAddresses.add(operator.toLowerCase()))
+      landActionPermissions.updateOperators.forEach((operator) => extraAddresses.add(operator.toLowerCase()))
+      landActionPermissions.updateManagers.forEach((operator) => extraAddresses.add(operator.toLowerCase()))
+      landActionPermissions.approvedForAll.forEach((operator) => extraAddresses.add(operator.toLowerCase()))
     }
 
     if (worldActionPermissions?.permissions.deployment.type === PermissionType.AllowList) {

--- a/src/adapters/scene-admins.ts
+++ b/src/adapters/scene-admins.ts
@@ -40,8 +40,12 @@ export async function createSceneAdminsComponent(
 
     if (landActionPermissions) {
       extraAddresses.add(landActionPermissions.owner.toLowerCase())
-      landActionPermissions.operators.forEach((operator) => extraAddresses.add(operator.toLowerCase()))
-      landActionPermissions.updateOperators.forEach((operator) => extraAddresses.add(operator.toLowerCase()))
+      if (landActionPermissions.operator) {
+        extraAddresses.add(landActionPermissions.operator.toLowerCase())
+      }
+      if (landActionPermissions.updateOperators) {
+        extraAddresses.add(landActionPermissions.updateOperators.toLowerCase())
+      }
       landActionPermissions.updateManagers.forEach((operator) => extraAddresses.add(operator.toLowerCase()))
       landActionPermissions.approvedForAll.forEach((operator) => extraAddresses.add(operator.toLowerCase()))
     }

--- a/src/adapters/scene-manager.ts
+++ b/src/adapters/scene-manager.ts
@@ -8,14 +8,14 @@ export async function createSceneManagerComponent(
   const { worlds, lands, sceneAdminManager } = components
 
   const { hasWorldOwnerPermission, hasWorldStreamingPermission, hasWorldDeployPermission } = worlds
-  const { getLandUpdatePermission } = lands
+  const { getLandPermissions } = lands
 
   async function isSceneOwner(place: PlaceAttributes, address: string): Promise<boolean> {
     const isWorlds = place.world
     if (isWorlds) {
       return await hasWorldOwnerPermission(address, place.world_name!)
     }
-    const landParcelPermission = await getLandUpdatePermission(address, place.positions)
+    const landParcelPermission = await getLandPermissions(address, place.positions)
     return landParcelPermission?.owner
   }
 
@@ -30,7 +30,12 @@ export async function createSceneManagerComponent(
       ])
       hasExtendedPermissions = hasStreamingPermission || hasDeployPermission
     } else if (!isAdmin && !place.world) {
-      hasExtendedPermissions = (await getLandUpdatePermission(address, place.positions)).operator
+      const landParcelPermission = await getLandPermissions(address, place.positions)
+      hasExtendedPermissions =
+        landParcelPermission.operator ||
+        landParcelPermission.updateOperator ||
+        landParcelPermission.updateManager ||
+        landParcelPermission.approvedForAll
     }
     return {
       owner: isOwner,

--- a/src/controllers/handlers/comms-scene-handler.ts
+++ b/src/controllers/handlers/comms-scene-handler.ts
@@ -1,8 +1,8 @@
+import { Events, UserJoinedRoomEvent } from '@dcl/schemas'
 import { IHttpServerComponent } from '@well-known-components/interfaces'
 import { HandlerContextWithPath, Permissions } from '../../types'
 import { InvalidRequestError, NotFoundError, UnauthorizedError } from '../../types/errors'
 import { oldValidate } from '../../logic/utils'
-import { Events, UserJoinedRoomEvent } from '@dcl/schemas'
 
 export async function commsSceneHandler(
   context: HandlerContextWithPath<

--- a/src/types/lands.type.ts
+++ b/src/types/lands.type.ts
@@ -1,16 +1,22 @@
 import { IBaseComponent } from '@well-known-components/interfaces'
 
 export type LandsParcelPermissionsResponse = {
-  operator: boolean
   owner: boolean
+  operator: boolean
+  updateOperator: boolean
+  updateManager: boolean
+  approvedForAll: boolean
 }
 
 export type LandsParcelOperatorsResponse = {
   owner: string
-  operator?: string
+  operators: string[]
+  updateOperators: string[]
+  updateManagers: string[]
+  approvedForAll: string[]
 }
 
 export type ILandComponent = IBaseComponent & {
-  getLandUpdatePermission(authAddress: string, placePositions: string[]): Promise<LandsParcelPermissionsResponse>
+  getLandPermissions(authAddress: string, placePositions: string[]): Promise<LandsParcelPermissionsResponse>
   getLandOperators(parcel: string): Promise<LandsParcelOperatorsResponse>
 }

--- a/src/types/lands.type.ts
+++ b/src/types/lands.type.ts
@@ -10,8 +10,8 @@ export type LandsParcelPermissionsResponse = {
 
 export type LandsParcelOperatorsResponse = {
   owner: string
-  operators: string[]
-  updateOperators: string[]
+  operator: string | null
+  updateOperators: string | null
   updateManagers: string[]
   approvedForAll: string[]
 }

--- a/test/integration/land-component.spec.ts
+++ b/test/integration/land-component.spec.ts
@@ -48,14 +48,22 @@ describe('LandsComponent', () => {
     it('should return owner=true when user has owner permission', async () => {
       const mockParcelPermissionsResponse: LandsParcelPermissionsResponse = {
         owner: true,
-        operator: false
+        operator: false,
+        updateOperator: false,
+        updateManager: false,
+        approvedForAll: false
       }
 
       mockFetch.mockResolvedValueOnce(mockParcelPermissionsResponse)
 
-      const result = await landsComponent.getLandUpdatePermission('0xUserAddress', ['10,20', '99,99'])
-      expect(result.owner).toBe(true)
-      expect(result.operator).toBe(false)
+      const result = await landsComponent.getLandPermissions('0xUserAddress', ['10,20', '99,99'])
+      expect(result).toEqual({
+        owner: true,
+        operator: false,
+        updateOperator: false,
+        updateManager: false,
+        approvedForAll: false
+      })
       expect(mockFetch).toHaveBeenCalledWith(
         'https://lambdas.decentraland.org/api/users/0xUserAddress/parcels/10/20/permissions'
       )
@@ -64,14 +72,22 @@ describe('LandsComponent', () => {
     it('should return operator=true when user has operator permission', async () => {
       const mockParcelPermissionsResponse: LandsParcelPermissionsResponse = {
         owner: false,
-        operator: true
+        operator: true,
+        updateOperator: false,
+        updateManager: false,
+        approvedForAll: false
       }
 
       mockFetch.mockResolvedValueOnce(mockParcelPermissionsResponse)
 
-      const result = await landsComponent.getLandUpdatePermission('0xUserAddress', ['50,60', '99,99'])
-      expect(result.owner).toBe(false)
-      expect(result.operator).toBe(true)
+      const result = await landsComponent.getLandPermissions('0xUserAddress', ['50,60', '99,99'])
+      expect(result).toEqual({
+        owner: false,
+        operator: true,
+        updateOperator: false,
+        updateManager: false,
+        approvedForAll: false
+      })
       expect(mockFetch).toHaveBeenCalledWith(
         'https://lambdas.decentraland.org/api/users/0xUserAddress/parcels/50/60/permissions'
       )
@@ -80,7 +96,7 @@ describe('LandsComponent', () => {
     it('should throw an error when permission response is not available', async () => {
       mockFetch.mockResolvedValueOnce(null)
 
-      await expect(landsComponent.getLandUpdatePermission('0xUserAddress', ['10,20'])).rejects.toThrow(
+      await expect(landsComponent.getLandPermissions('0xUserAddress', ['10,20'])).rejects.toThrow(
         'Land permissions not found for 0xUserAddress at 10,20'
       )
       expect(mockFetch).toHaveBeenCalledWith(
@@ -111,9 +127,7 @@ describe('LandsComponent', () => {
         }
       })
 
-      await expect(component.getLandUpdatePermission('0xUserAddress', ['10,20'])).rejects.toThrow(
-        'Lambdas URL is not set'
-      )
+      await expect(component.getLandPermissions('0xUserAddress', ['10,20'])).rejects.toThrow('Lambdas URL is not set')
     })
   })
 
@@ -121,27 +135,110 @@ describe('LandsComponent', () => {
     it('should return owner and operator when both exist', async () => {
       const mockParcelOperatorsResponse: LandsParcelOperatorsResponse = {
         owner: '0xOwnerAddress',
-        operator: '0xOperatorAddress'
+        operators: ['0xOperatorAddress'],
+        updateOperators: [],
+        updateManagers: [],
+        approvedForAll: []
       }
 
       mockFetch.mockResolvedValueOnce(mockParcelOperatorsResponse)
 
       const result = await landsComponent.getLandOperators('10,20')
-      expect(result.owner).toBe('0xOwnerAddress')
-      expect(result.operator).toBe('0xOperatorAddress')
+      expect(result).toEqual({
+        owner: '0xOwnerAddress',
+        operators: ['0xOperatorAddress'],
+        updateOperators: [],
+        updateManagers: [],
+        approvedForAll: []
+      })
+      expect(mockFetch).toHaveBeenCalledWith('https://lambdas.decentraland.org/api/parcels/10/20/operators')
+    })
+
+    it('should return update operator when update operator exists', async () => {
+      const mockParcelOperatorsResponse: LandsParcelOperatorsResponse = {
+        owner: '0xOwnerAddress',
+        operators: [],
+        updateOperators: ['0xUpdateOperatorAddress'],
+        updateManagers: [],
+        approvedForAll: []
+      }
+
+      mockFetch.mockResolvedValueOnce(mockParcelOperatorsResponse)
+
+      const result = await landsComponent.getLandOperators('10,20')
+      expect(result).toEqual({
+        owner: '0xOwnerAddress',
+        operators: [],
+        updateOperators: ['0xUpdateOperatorAddress'],
+        updateManagers: [],
+        approvedForAll: []
+      })
+      expect(mockFetch).toHaveBeenCalledWith('https://lambdas.decentraland.org/api/parcels/10/20/operators')
+    })
+
+    it('should return update manager when update manager exists', async () => {
+      const mockParcelOperatorsResponse: LandsParcelOperatorsResponse = {
+        owner: '0xOwnerAddress',
+        operators: [],
+        updateOperators: [],
+        updateManagers: ['0xUpdateManagerAddress'],
+        approvedForAll: []
+      }
+
+      mockFetch.mockResolvedValueOnce(mockParcelOperatorsResponse)
+
+      const result = await landsComponent.getLandOperators('10,20')
+      expect(result).toEqual({
+        owner: '0xOwnerAddress',
+        operators: [],
+        updateOperators: [],
+        updateManagers: ['0xUpdateManagerAddress'],
+        approvedForAll: []
+      })
+      expect(mockFetch).toHaveBeenCalledWith('https://lambdas.decentraland.org/api/parcels/10/20/operators')
+    })
+
+    it('should return approved for all when approved for all exists', async () => {
+      const mockParcelOperatorsResponse: LandsParcelOperatorsResponse = {
+        owner: '0xOwnerAddress',
+        operators: [],
+        updateOperators: [],
+        updateManagers: [],
+        approvedForAll: ['0xApprovedForAllAddress']
+      }
+
+      mockFetch.mockResolvedValueOnce(mockParcelOperatorsResponse)
+
+      const result = await landsComponent.getLandOperators('10,20')
+      expect(result).toEqual({
+        owner: '0xOwnerAddress',
+        operators: [],
+        updateOperators: [],
+        updateManagers: [],
+        approvedForAll: ['0xApprovedForAllAddress']
+      })
       expect(mockFetch).toHaveBeenCalledWith('https://lambdas.decentraland.org/api/parcels/10/20/operators')
     })
 
     it('should return only owner when operator does not exist', async () => {
       const mockParcelOperatorsResponse: LandsParcelOperatorsResponse = {
-        owner: '0xOwnerAddress'
+        owner: '0xOwnerAddress',
+        operators: [],
+        updateOperators: [],
+        updateManagers: [],
+        approvedForAll: []
       }
 
       mockFetch.mockResolvedValueOnce(mockParcelOperatorsResponse)
 
       const result = await landsComponent.getLandOperators('10,20')
-      expect(result.owner).toBe('0xOwnerAddress')
-      expect(result.operator).toBeUndefined()
+      expect(result).toEqual({
+        owner: '0xOwnerAddress',
+        operators: [],
+        updateOperators: [],
+        updateManagers: [],
+        approvedForAll: []
+      })
       expect(mockFetch).toHaveBeenCalledWith('https://lambdas.decentraland.org/api/parcels/10/20/operators')
     })
 

--- a/test/integration/land-component.spec.ts
+++ b/test/integration/land-component.spec.ts
@@ -135,8 +135,8 @@ describe('LandsComponent', () => {
     it('should return owner and operator when both exist', async () => {
       const mockParcelOperatorsResponse: LandsParcelOperatorsResponse = {
         owner: '0xOwnerAddress',
-        operators: ['0xOperatorAddress'],
-        updateOperators: [],
+        operator: '0xOperatorAddress',
+        updateOperators: null,
         updateManagers: [],
         approvedForAll: []
       }
@@ -146,8 +146,8 @@ describe('LandsComponent', () => {
       const result = await landsComponent.getLandOperators('10,20')
       expect(result).toEqual({
         owner: '0xOwnerAddress',
-        operators: ['0xOperatorAddress'],
-        updateOperators: [],
+        operator: '0xOperatorAddress',
+        updateOperators: null,
         updateManagers: [],
         approvedForAll: []
       })
@@ -157,8 +157,8 @@ describe('LandsComponent', () => {
     it('should return update operator when update operator exists', async () => {
       const mockParcelOperatorsResponse: LandsParcelOperatorsResponse = {
         owner: '0xOwnerAddress',
-        operators: [],
-        updateOperators: ['0xUpdateOperatorAddress'],
+        operator: null,
+        updateOperators: '0xUpdateOperatorAddress',
         updateManagers: [],
         approvedForAll: []
       }
@@ -168,8 +168,8 @@ describe('LandsComponent', () => {
       const result = await landsComponent.getLandOperators('10,20')
       expect(result).toEqual({
         owner: '0xOwnerAddress',
-        operators: [],
-        updateOperators: ['0xUpdateOperatorAddress'],
+        operator: null,
+        updateOperators: '0xUpdateOperatorAddress',
         updateManagers: [],
         approvedForAll: []
       })
@@ -179,8 +179,8 @@ describe('LandsComponent', () => {
     it('should return update manager when update manager exists', async () => {
       const mockParcelOperatorsResponse: LandsParcelOperatorsResponse = {
         owner: '0xOwnerAddress',
-        operators: [],
-        updateOperators: [],
+        operator: null,
+        updateOperators: null,
         updateManagers: ['0xUpdateManagerAddress'],
         approvedForAll: []
       }
@@ -190,8 +190,8 @@ describe('LandsComponent', () => {
       const result = await landsComponent.getLandOperators('10,20')
       expect(result).toEqual({
         owner: '0xOwnerAddress',
-        operators: [],
-        updateOperators: [],
+        operator: null,
+        updateOperators: null,
         updateManagers: ['0xUpdateManagerAddress'],
         approvedForAll: []
       })
@@ -201,8 +201,8 @@ describe('LandsComponent', () => {
     it('should return approved for all when approved for all exists', async () => {
       const mockParcelOperatorsResponse: LandsParcelOperatorsResponse = {
         owner: '0xOwnerAddress',
-        operators: [],
-        updateOperators: [],
+        operator: null,
+        updateOperators: null,
         updateManagers: [],
         approvedForAll: ['0xApprovedForAllAddress']
       }
@@ -212,8 +212,8 @@ describe('LandsComponent', () => {
       const result = await landsComponent.getLandOperators('10,20')
       expect(result).toEqual({
         owner: '0xOwnerAddress',
-        operators: [],
-        updateOperators: [],
+        operator: null,
+        updateOperators: null,
         updateManagers: [],
         approvedForAll: ['0xApprovedForAllAddress']
       })
@@ -223,8 +223,8 @@ describe('LandsComponent', () => {
     it('should return only owner when operator does not exist', async () => {
       const mockParcelOperatorsResponse: LandsParcelOperatorsResponse = {
         owner: '0xOwnerAddress',
-        operators: [],
-        updateOperators: [],
+        operator: null,
+        updateOperators: null,
         updateManagers: [],
         approvedForAll: []
       }
@@ -234,8 +234,8 @@ describe('LandsComponent', () => {
       const result = await landsComponent.getLandOperators('10,20')
       expect(result).toEqual({
         owner: '0xOwnerAddress',
-        operators: [],
-        updateOperators: [],
+        operator: null,
+        updateOperators: null,
         updateManagers: [],
         approvedForAll: []
       })

--- a/test/integration/scene-admin/add-scene-admin-handler.spec.ts
+++ b/test/integration/scene-admin/add-scene-admin-handler.spec.ts
@@ -67,7 +67,13 @@ test('POST /scene-admin - adds administrator access for a scene who can add othe
       world: true
     } as PlaceAttributes)
 
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: true, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: true,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.sceneManager.getUserScenePermissions.resolves({
       owner: false,
       admin: false,
@@ -191,7 +197,13 @@ test('POST /scene-admin - adds administrator access for a scene who can add othe
   it('returns 204 when user has operator permission', async () => {
     const { localFetch } = components
 
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: false, operator: true })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: false,
+      operator: true,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
 
     stubComponents.sceneManager.getUserScenePermissions.resolves({
       owner: false,
@@ -276,7 +288,13 @@ test('POST /scene-admin - adds administrator access for a scene who can add othe
   it('returns 401 when user is not owner or admin', async () => {
     const { localFetch } = components
 
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: false, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: false,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.worlds.hasWorldOwnerPermission.resolves(false)
     stubComponents.sceneAdminManager.isAdmin.resolves(false)
     stubComponents.sceneManager.getUserScenePermissions.resolves({

--- a/test/integration/scene-admin/remove-scene-admin-handler.spec.ts
+++ b/test/integration/scene-admin/remove-scene-admin-handler.spec.ts
@@ -102,7 +102,13 @@ test('DELETE /scene-admin - removes administrator access for a scene', ({ compon
       owner: ownerAddress
     } as PlaceAttributes)
 
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: false, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: false,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.worlds.hasWorldStreamingPermission.resolves(false)
     stubComponents.worlds.hasWorldDeployPermission.resolves(false)
     stubComponents.sceneAdminManager.isAdmin.resolves(false)

--- a/test/integration/scene-manager-component.spec.ts
+++ b/test/integration/scene-manager-component.spec.ts
@@ -15,7 +15,13 @@ test('SceneManagerComponent', ({ stubComponents }) => {
     stubComponents.worlds.hasWorldOwnerPermission.resolves(false)
     stubComponents.worlds.hasWorldStreamingPermission.resolves(false)
     stubComponents.worlds.hasWorldDeployPermission.resolves(false)
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: false, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: false,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.sceneAdminManager.isAdmin.resolves(false)
 
     sceneManager = await createSceneManagerComponent({
@@ -45,7 +51,13 @@ test('SceneManagerComponent', ({ stubComponents }) => {
     })
 
     it('should return true when user has land owner permission', async () => {
-      stubComponents.lands.getLandUpdatePermission.resolves({ owner: true, operator: false })
+      stubComponents.lands.getLandPermissions.resolves({
+        owner: true,
+        operator: false,
+        updateOperator: false,
+        updateManager: false,
+        approvedForAll: false
+      })
       const result = await sceneManager.isSceneOwner(scenePlace, testAddress)
       expect(result).toBe(true)
     })
@@ -97,8 +109,66 @@ test('SceneManagerComponent', ({ stubComponents }) => {
       })
     })
 
-    it('should return hasExtendedPermissions=true if user is an operator of a scene', async () => {
-      stubComponents.lands.getLandUpdatePermission.resolves({ owner: false, operator: true })
+    it('should return hasExtendedPermissions as true if user is an operator of a scene', async () => {
+      stubComponents.lands.getLandPermissions.resolves({
+        owner: false,
+        operator: true,
+        updateOperator: false,
+        updateManager: false,
+        approvedForAll: false
+      })
+
+      const result = await sceneManager.getUserScenePermissions(scenePlace, testAddress)
+      expect(result).toEqual({
+        owner: false,
+        admin: false,
+        hasExtendedPermissions: true
+      })
+    })
+
+    it('should return hasExtendedPermissions as true if user is an update operator of a scene', async () => {
+      stubComponents.lands.getLandPermissions.resolves({
+        owner: false,
+        operator: false,
+        updateOperator: true,
+        updateManager: false,
+        approvedForAll: false
+      })
+
+      const result = await sceneManager.getUserScenePermissions(scenePlace, testAddress)
+      expect(result).toEqual({
+        owner: false,
+        admin: false,
+        hasExtendedPermissions: true
+      })
+    })
+
+    it('should return hasExtendedPermissions as true if user is an update manager of a scene', async () => {
+      stubComponents.lands.getLandPermissions.resolves({
+        owner: false,
+        operator: false,
+        updateOperator: false,
+        updateManager: true,
+        approvedForAll: false
+      })
+
+      const result = await sceneManager.getUserScenePermissions(scenePlace, testAddress)
+      expect(result).toEqual({
+        owner: false,
+        admin: false,
+        hasExtendedPermissions: true
+      })
+    })
+
+    it('should return hasExtendedPermissions as true if user is approved for all of a scene', async () => {
+      stubComponents.lands.getLandPermissions.resolves({
+        owner: false,
+        operator: false,
+        updateOperator: false,
+        updateManager: false,
+        approvedForAll: true
+      })
+
       const result = await sceneManager.getUserScenePermissions(scenePlace, testAddress)
       expect(result).toEqual({
         owner: false,
@@ -108,6 +178,14 @@ test('SceneManagerComponent', ({ stubComponents }) => {
     })
 
     it('should return all false if user has no privileges for a scene', async () => {
+      stubComponents.lands.getLandPermissions.resolves({
+        owner: false,
+        operator: false,
+        updateOperator: false,
+        updateManager: false,
+        approvedForAll: false
+      })
+
       const result = await sceneManager.getUserScenePermissions(scenePlace, testAddress)
       expect(result).toEqual({
         owner: false,
@@ -128,7 +206,13 @@ test('SceneManagerComponent', ({ stubComponents }) => {
 
   describe('isSceneOwnerOrAdmin', () => {
     it('should return true when user is owner', async () => {
-      stubComponents.lands.getLandUpdatePermission.resolves({ owner: true, operator: false })
+      stubComponents.lands.getLandPermissions.resolves({
+        owner: true,
+        operator: false,
+        updateOperator: false,
+        updateManager: false,
+        approvedForAll: false
+      })
       const result = await sceneManager.isSceneOwnerOrAdmin(scenePlace, testAddress)
       expect(result).toBe(true)
     })
@@ -139,9 +223,57 @@ test('SceneManagerComponent', ({ stubComponents }) => {
       expect(result).toBe(true)
     })
 
-    it('should return true when user has extended permissions', async () => {
+    it('should return true when user has extended permissions from having world streaming permission', async () => {
       stubComponents.worlds.hasWorldStreamingPermission.resolves(true)
       const result = await sceneManager.isSceneOwnerOrAdmin(worldPlace, testAddress)
+      expect(result).toBe(true)
+    })
+
+    it('should return true when user has extended permissions from having update manager permission', async () => {
+      stubComponents.lands.getLandPermissions.resolves({
+        owner: false,
+        operator: false,
+        updateOperator: false,
+        updateManager: true,
+        approvedForAll: false
+      })
+      const result = await sceneManager.isSceneOwnerOrAdmin(scenePlace, testAddress)
+      expect(result).toBe(true)
+    })
+
+    it('should return true when user has extended permissions from having operator permission', async () => {
+      stubComponents.lands.getLandPermissions.resolves({
+        owner: false,
+        operator: true,
+        updateOperator: false,
+        updateManager: false,
+        approvedForAll: false
+      })
+      const result = await sceneManager.isSceneOwnerOrAdmin(scenePlace, testAddress)
+      expect(result).toBe(true)
+    })
+
+    it('should return true when user has extended permissions from having update operator permission', async () => {
+      stubComponents.lands.getLandPermissions.resolves({
+        owner: false,
+        operator: false,
+        updateOperator: true,
+        updateManager: false,
+        approvedForAll: false
+      })
+      const result = await sceneManager.isSceneOwnerOrAdmin(scenePlace, testAddress)
+      expect(result).toBe(true)
+    })
+
+    it('should return true when user has extended permissions from having approved for all permission', async () => {
+      stubComponents.lands.getLandPermissions.resolves({
+        owner: false,
+        operator: false,
+        updateOperator: false,
+        updateManager: false,
+        approvedForAll: true
+      })
+      const result = await sceneManager.isSceneOwnerOrAdmin(scenePlace, testAddress)
       expect(result).toBe(true)
     })
 

--- a/test/integration/scene-stream-access/add-scene-stream-access-handler.spec.ts
+++ b/test/integration/scene-stream-access/add-scene-stream-access-handler.spec.ts
@@ -85,7 +85,13 @@ test('GET /scene-stream-access - gets streaming access for scenes', ({ component
       owner: owner.authChain[0].payload
     } as PlaceAttributes)
 
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: true, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: true,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.worlds.hasWorldOwnerPermission.resolves(false)
     stubComponents.sceneAdminManager.isAdmin.resolves(false)
     stubComponents.livekit.getSceneRoomName.resolves(`test-realm:test-scene`)
@@ -172,7 +178,13 @@ test('GET /scene-stream-access - gets streaming access for scenes', ({ component
   it('returns 200 with streaming access when user is an admin', async () => {
     const { localFetch } = components
 
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: false, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: false,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.worlds.hasWorldOwnerPermission.resolves(false)
     stubComponents.sceneAdminManager.isAdmin.resolves(true)
     stubComponents.sceneManager.getUserScenePermissions.resolves({
@@ -245,7 +257,13 @@ test('GET /scene-stream-access - gets streaming access for scenes', ({ component
   it('returns 401 when user is not owner or admin', async () => {
     const { localFetch } = components
 
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: false, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: false,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.worlds.hasWorldOwnerPermission.resolves(false)
     stubComponents.sceneAdminManager.isAdmin.resolves(false)
     stubComponents.sceneManager.getUserScenePermissions.resolves({
@@ -393,7 +411,13 @@ test('POST /scene-stream-access - adds streaming access for a scene', ({ compone
       owner: owner.authChain[0].payload
     } as PlaceAttributes)
 
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: true, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: true,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.worlds.hasWorldOwnerPermission.resolves(false)
     stubComponents.sceneAdminManager.isAdmin.resolves(false)
     stubComponents.sceneStreamAccessManager.addAccess.resolves(mockSceneStreamAccess)
@@ -475,7 +499,13 @@ test('POST /scene-stream-access - adds streaming access for a scene', ({ compone
   it('returns 200 with streaming access when is an admin', async () => {
     const { localFetch } = components
 
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: false, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: false,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.worlds.hasWorldOwnerPermission.resolves(false)
     stubComponents.sceneAdminManager.isAdmin.resolves(true)
     stubComponents.sceneManager.getUserScenePermissions.resolves({
@@ -508,7 +538,13 @@ test('POST /scene-stream-access - adds streaming access for a scene', ({ compone
   it('returns 401 when user is not authorized', async () => {
     const { localFetch } = components
 
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: false, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: false,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.worlds.hasWorldOwnerPermission.resolves(false)
     stubComponents.sceneAdminManager.isAdmin.resolves(false)
     stubComponents.sceneManager.getUserScenePermissions.resolves({
@@ -540,7 +576,13 @@ test('POST /scene-stream-access - adds streaming access for a scene', ({ compone
     stubComponents.sceneStreamAccessManager.addAccess.rejects(
       new StreamingAccessNotFoundError('Streaming access unavailable')
     )
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: true, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: true,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.worlds.hasWorldOwnerPermission.resolves(false)
     stubComponents.sceneAdminManager.isAdmin.resolves(false)
     stubComponents.sceneManager.getUserScenePermissions.resolves({

--- a/test/integration/scene-stream-access/get-scene-stream-access-handler.spec.ts
+++ b/test/integration/scene-stream-access/get-scene-stream-access-handler.spec.ts
@@ -94,7 +94,13 @@ test('GET /scene-stream-access - gets streaming access for scenes', ({ component
       world_name: 'name.dcl.eth',
       owner: owner.authChain[0].payload
     } as PlaceAttributes)
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: true, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: true,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.worlds.hasWorldOwnerPermission.resolves(false)
     stubComponents.worlds.hasWorldStreamingPermission.resolves(false)
     stubComponents.worlds.hasWorldDeployPermission.resolves(false)
@@ -190,7 +196,13 @@ test('GET /scene-stream-access - gets streaming access for scenes', ({ component
     const { localFetch } = components
     stubComponents.sceneManager.isSceneOwnerOrAdmin.resolves(true)
 
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: false, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: false,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.worlds.hasWorldOwnerPermission.resolves(false)
     stubComponents.sceneAdminManager.isAdmin.resolves(true)
     stubComponents.sceneManager.getUserScenePermissions.resolves({
@@ -260,7 +272,13 @@ test('GET /scene-stream-access - gets streaming access for scenes', ({ component
   it('returns 401 when user is not owner or admin', async () => {
     const { localFetch } = components
 
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: false, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: false,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.worlds.hasWorldOwnerPermission.resolves(false)
     stubComponents.sceneAdminManager.isAdmin.resolves(false)
     stubComponents.sceneManager.getUserScenePermissions.resolves({

--- a/test/integration/scene-stream-access/list-scene-stream-access-handler.spec.ts
+++ b/test/integration/scene-stream-access/list-scene-stream-access-handler.spec.ts
@@ -76,7 +76,13 @@ test('GET /scene-stream-access - lists streaming access for scenes', ({ componen
       world_name: 'name.dcl.eth',
       owner: owner.authChain[0].payload
     } as PlaceAttributes)
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: true, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: true,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.worlds.hasWorldOwnerPermission.resolves(false)
     stubComponents.sceneAdminManager.isAdmin.resolves(false)
     stubComponents.sceneStreamAccessManager.getAccess.resolves(mockSceneStreamAccess)
@@ -129,7 +135,13 @@ test('GET /scene-stream-access - lists streaming access for scenes', ({ componen
       id: placeWorldId,
       world_name: 'name.dcl.eth'
     } as PlaceAttributes)
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: false, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: false,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.worlds.hasWorldOwnerPermission.resolves(true)
     stubComponents.sceneManager.getUserScenePermissions.resolves({
       owner: true,
@@ -161,7 +173,13 @@ test('GET /scene-stream-access - lists streaming access for scenes', ({ componen
   it('returns 200 with streaming access when user is an admin', async () => {
     const { localFetch } = components
 
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: false, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: false,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.worlds.hasWorldOwnerPermission.resolves(false)
     stubComponents.sceneAdminManager.isAdmin.resolves(true)
     stubComponents.sceneManager.getUserScenePermissions.resolves({
@@ -194,7 +212,13 @@ test('GET /scene-stream-access - lists streaming access for scenes', ({ componen
   it('returns 401 when user is not owner or admin', async () => {
     const { localFetch } = components
 
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: false, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: false,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.worlds.hasWorldOwnerPermission.resolves(false)
     stubComponents.sceneAdminManager.isAdmin.resolves(false)
     stubComponents.sceneManager.getUserScenePermissions.resolves({

--- a/test/integration/scene-stream-access/remove-scene-stream-access-handler.spec.ts
+++ b/test/integration/scene-stream-access/remove-scene-stream-access-handler.spec.ts
@@ -143,7 +143,13 @@ test('DELETE /scene-stream-access - removes streaming access for scenes', ({ com
   it('returns 204 when user is an admin and successfully removes streaming access', async () => {
     const { localFetch } = components
 
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: false, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: false,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.worlds.hasWorldOwnerPermission.resolves(false)
     stubComponents.sceneAdminManager.isAdmin.resolves(true)
     stubComponents.sceneManager.getUserScenePermissions.resolves({

--- a/test/integration/scene-stream-access/reset-scene-stream-access-handler.spec.ts
+++ b/test/integration/scene-stream-access/reset-scene-stream-access-handler.spec.ts
@@ -95,7 +95,13 @@ test('PUT /scene-stream-access - resets streaming access for scenes', ({ compone
       owner: owner.authChain[0].payload
     } as PlaceAttributes)
 
-    stubComponents.lands.getLandUpdatePermission.resolves({ owner: true, operator: false })
+    stubComponents.lands.getLandPermissions.resolves({
+      owner: true,
+      operator: false,
+      updateOperator: false,
+      updateManager: false,
+      approvedForAll: false
+    })
     stubComponents.sceneManager.isSceneOwnerOrAdmin.resolves(true)
     stubComponents.livekit.getSceneRoomName.resolves(`test-realm:test-scene`)
     stubComponents.livekit.getWorldRoomName.resolves(`name.dcl.eth`)

--- a/test/unit/scene-admins.spec.ts
+++ b/test/unit/scene-admins.spec.ts
@@ -96,7 +96,10 @@ describe('SceneAdmins', () => {
 
       const mockLandOperators = {
         owner: '0xlandowner1',
-        operator: '0xoperator1'
+        operators: ['0xoperator1'],
+        updateOperators: [],
+        updateManagers: [],
+        approvedForAll: []
       }
 
       mockedComponents.sceneAdminManager.listActiveAdmins.mockResolvedValue([mockAdmin])
@@ -135,7 +138,10 @@ describe('SceneAdmins', () => {
 
       const mockLandOperators = {
         owner: '0xlandowner1',
-        operator: '0xoperator1'
+        operators: ['0xoperator1'],
+        updateOperators: [],
+        updateManagers: [],
+        approvedForAll: []
       }
 
       mockedComponents.sceneAdminManager.listActiveAdmins.mockResolvedValue([mockAdmin])

--- a/test/unit/scene-admins.spec.ts
+++ b/test/unit/scene-admins.spec.ts
@@ -96,8 +96,8 @@ describe('SceneAdmins', () => {
 
       const mockLandOperators = {
         owner: '0xlandowner1',
-        operators: ['0xoperator1'],
-        updateOperators: [],
+        operator: '0xoperator1',
+        updateOperators: null,
         updateManagers: [],
         approvedForAll: []
       }
@@ -138,8 +138,8 @@ describe('SceneAdmins', () => {
 
       const mockLandOperators = {
         owner: '0xlandowner1',
-        operators: ['0xoperator1'],
-        updateOperators: [],
+        operator: '0xoperator1',
+        updateOperators: null,
         updateManagers: [],
         approvedForAll: []
       }


### PR DESCRIPTION
This PR uses the newley improved lam2 API which contains more information about the permissions a land has.
Related to https://github.com/decentraland/lamb2/pull/404