### PR TITLE
fix: Respond with LiveKit connection url for voice chat credentials

### DIFF
--- a/src/adapters/livekit.ts
+++ b/src/adapters/livekit.ts
@@ -165,7 +165,12 @@ export async function createLivekitComponent(
     return receiver.receive(body, authorization)
   }
 
+  function buildConnectionUrl(url: string, token: string): string {
+    return `livekit:${url}?access_token=${token}`
+  }
+
   return {
+    buildConnectionUrl,
     deleteRoom,
     updateParticipantMetadata,
     generateCredentials,

--- a/src/controllers/handlers/comms-scene-handler.ts
+++ b/src/controllers/handlers/comms-scene-handler.ts
@@ -82,7 +82,7 @@ export async function commsSceneHandler(
   return {
     status: 200,
     body: {
-      adapter: `livekit:${credentials.url}?access_token=${credentials.token}`
+      adapter: livekit.buildConnectionUrl(credentials.url, credentials.token)
     }
   }
 }

--- a/src/controllers/handlers/voice-chat/create-private-voice-chat-handler.ts
+++ b/src/controllers/handlers/voice-chat/create-private-voice-chat-handler.ts
@@ -49,6 +49,13 @@ export async function createPrivateVoiceChatCredentialsHandler(
 
   return {
     status: 200,
-    body: credentials
+    body: Object.entries(credentials).reduce(
+      (acc, [userAddress, { connectionUrl }]) => {
+        // Re-build the object to be snake case.
+        acc[userAddress] = { connection_url: connectionUrl }
+        return acc
+      },
+      {} as Record<string, { connection_url: string }>
+    )
   }
 }

--- a/src/logic/voice/types.ts
+++ b/src/logic/voice/types.ts
@@ -1,5 +1,4 @@
 import { DisconnectReason } from '@livekit/protocol'
-import { LivekitCredentials } from '../../types/livekit.type'
 
 export interface IVoiceComponent {
   /**
@@ -33,7 +32,7 @@ export interface IVoiceComponent {
   getPrivateVoiceChatRoomCredentials(
     roomId: string,
     userAddresses: string[]
-  ): Promise<Record<string, LivekitCredentials>>
+  ): Promise<Record<string, { connectionUrl: string }>>
 
   /**
    * Ends a private voice chat room.

--- a/src/logic/voice/voice.ts
+++ b/src/logic/voice/voice.ts
@@ -1,7 +1,6 @@
 import { DisconnectReason } from '@livekit/protocol'
 import { AppComponents } from '../../types'
 import { IVoiceComponent } from './types'
-import { LivekitCredentials } from '../../types/livekit.type'
 import { getPrivateVoiceChatRoomName } from './utils'
 
 export function createVoiceComponent(components: Pick<AppComponents, 'voiceDB' | 'logs' | 'livekit'>): IVoiceComponent {
@@ -80,7 +79,7 @@ export function createVoiceComponent(components: Pick<AppComponents, 'voiceDB' |
   async function getPrivateVoiceChatRoomCredentials(
     roomId: string,
     userAddresses: string[]
-  ): Promise<Record<string, LivekitCredentials>> {
+  ): Promise<Record<string, { connectionUrl: string }>> {
     const roomName = getPrivateVoiceChatRoomName(roomId)
     // Generate credentials for each user.
     const roomKeys = await Promise.all(
@@ -103,10 +102,10 @@ export function createVoiceComponent(components: Pick<AppComponents, 'voiceDB' |
     await voiceDB.createVoiceChatRoom(roomName, userAddresses)
     return userAddresses.reduce(
       (acc, userAddress, index) => {
-        acc[userAddress] = roomKeys[index]
+        acc[userAddress] = { connectionUrl: livekit.buildConnectionUrl(roomKeys[index].url, roomKeys[index].token) }
         return acc
       },
-      {} as Record<string, LivekitCredentials>
+      {} as Record<string, { connectionUrl: string }>
     )
   }
 

--- a/src/types/livekit.type.ts
+++ b/src/types/livekit.type.ts
@@ -15,6 +15,7 @@ export type LivekitSettings = {
 
 export type ILivekitComponent = IBaseComponent & {
   deleteRoom: (roomName: string) => Promise<void>
+  buildConnectionUrl: (url: string, token: string) => string
   generateCredentials: (
     identity: string,
     roomId: string,

--- a/test/integration/voice-chat/create-private-voice-chat-credentials-handler.spec.ts
+++ b/test/integration/voice-chat/create-private-voice-chat-credentials-handler.spec.ts
@@ -292,6 +292,14 @@ test('POST /private-voice-chat', ({ components, spyComponents }) => {
           const body = await response.json()
 
           expect(response.status).toBe(200)
+          expect(body).toEqual({
+            [validAddress1.toLowerCase()]: {
+              connection_url: `livekit:${mockCredentials[validAddress1.toLowerCase()].url}?access_token=${mockCredentials[validAddress1.toLowerCase()].token}`
+            },
+            [validAddress2.toLowerCase()]: {
+              connection_url: `livekit:${mockCredentials[validAddress2.toLowerCase()].url}?access_token=${mockCredentials[validAddress2.toLowerCase()].token}`
+            }
+          })
           await expect(
             components.voiceDB.getUsersInRoom(getPrivateVoiceChatRoomName(requestBody.room_id))
           ).resolves.toEqual([
@@ -310,7 +318,6 @@ test('POST /private-voice-chat', ({ components, spyComponents }) => {
               statusUpdatedAt: expect.any(Number)
             }
           ])
-          expect(body).toEqual(mockCredentials)
         })
       })
     })

--- a/test/unit/voice-logic.spec.ts
+++ b/test/unit/voice-logic.spec.ts
@@ -40,7 +40,8 @@ describe('voice logic component', () => {
 
     livekit = {
       deleteRoom: deleteRoomMock,
-      generateCredentials: generateCredentialsMock
+      generateCredentials: generateCredentialsMock,
+      buildConnectionUrl: (url: string, token: string) => `livekit:${url}?access_token=${token}`
     } as jest.Mocked<ILivekitComponent>
 
     voiceDB = createMockedVoiceDBComponent({
@@ -239,6 +240,7 @@ describe('voice logic component', () => {
 
         generateCredentialsMock.mockResolvedValueOnce(mockCredentials[0]).mockResolvedValueOnce(mockCredentials[1])
       })
+
       it('should generate credentials for all users, create the room and resolve with the credentials', async () => {
         const result = await voiceComponent.getPrivateVoiceChatRoomCredentials(roomId, userAddresses)
 
@@ -269,8 +271,12 @@ describe('voice logic component', () => {
         )
         expect(createVoiceChatRoomMock).toHaveBeenCalledWith(expectedRoomName, userAddresses)
         expect(result).toEqual({
-          [userAddresses[0]]: mockCredentials[0],
-          [userAddresses[1]]: mockCredentials[1]
+          [userAddresses[0]]: {
+            connectionUrl: `livekit:${mockCredentials[0].url}?access_token=${mockCredentials[0].token}`
+          },
+          [userAddresses[1]]: {
+            connectionUrl: `livekit:${mockCredentials[1].url}?access_token=${mockCredentials[1].token}`
+          }
         })
       })
     })


### PR DESCRIPTION
This PR changes the credentials endpoint to return a `connection_url` for each voice chat user instead of the url and the token.