### PR TITLE
fix: Privacy settings fetching with wrong url

### DIFF
--- a/src/adapters/social.ts
+++ b/src/adapters/social.ts
@@ -10,7 +10,7 @@ export async function createSocialComponent(
     logs,
     fetch: { fetch }
   } = components
-  const socialServiceUrl = config.requireString('SOCIAL_SERVICE_URL')
+  const socialServiceUrl = await config.requireString('SOCIAL_SERVICE_URL')
   const logger = logs.getLogger('social-component')
 
   async function getUserPrivacySettings(address: string): Promise<PrivacySettings> {


### PR DESCRIPTION
This PR fixes the `getUserPrivacySettings` method which was wrongfully getting the base URL of the social service from an not awaited promise. 