### PR TITLE
feat: Voice chat room deletion & logging

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -25,7 +25,7 @@ WORLD_CONTENT_URL=https://worlds-content-server.decentraland.org
 CATALYST_CONTENT_URL=https://peer.decentraland.org/content
 PLACES_API_URL=https://places.decentraland.org/api
 BLACKLIST_JSON_URL=https://config.decentraland.org/denylist.json
-SOCIAL_SERVICE_URL=https://social-service.decentraland.org
+SOCIAL_SERVICE_URL=https://social-service-ea.decentraland.org
 COMMS_GATEKEEPER_AUTH_TOKEN="aToken"
 WORLD_ROOM_PREFIX=
 SCENE_ROOM_PREFIX=
@@ -43,9 +43,9 @@ NOTIFICATION_SERVICE_URL=
 NOTIFICATION_SERVICE_TOKEN=
 
 # Voice chat connection interrupted TTL in MS
-VOICE_CHAT_CONNECTION_INTERRUPTED_TTL=30000
+VOICE_CHAT_CONNECTION_INTERRUPTED_TTL=300000
 # Voice chat initial connection TTL in MS
-VOICE_CHAT_INITIAL_CONNECTION_TTL=30000
+VOICE_CHAT_INITIAL_CONNECTION_TTL=300000
 
 VOICE_CHAT_EXPIRED_BATCH_SIZE=50
 ANALYTICS_CONTEXT="comms-gatekeeper"

--- a/src/adapters/db/types.ts
+++ b/src/adapters/db/types.ts
@@ -69,11 +69,12 @@ export interface IVoiceDBComponent {
 
   /**
    * Deletes a private voice chat from the database by removing all users from the room.
+   * If the given address is or was not in the room, an error is thrown.
    * @param roomName - The name of the room to remove.
-   * @param address - The address of the user to remove from the room.
+   * @param address - An address of an user that was or is in the room.
    * @returns The addresses of the users that were in the deleted room.
    */
-  deletePrivateVoiceChat: (roomName: string, address: string) => Promise<string[]>
+  deletePrivateVoiceChatUserIsOrWasIn: (roomName: string, address: string) => Promise<string[]>
 
   /**
    * Gets the users in a room.
@@ -92,4 +93,10 @@ export interface IVoiceDBComponent {
    * @returns The names of the rooms that were deleted when the users were in the rooms.
    */
   deleteExpiredPrivateVoiceChats: () => Promise<string[]>
+
+  /**
+   * Deletes a private voice chat room from the database without any checks.
+   * @param roomName - The name of the room to delete.
+   */
+  deletePrivateVoiceChat: (roomName: string) => Promise<void>
 }

--- a/src/adapters/livekit.ts
+++ b/src/adapters/livekit.ts
@@ -100,6 +100,7 @@ export async function createLivekitComponent(
   }
 
   async function deleteRoom(roomName: string): Promise<void> {
+    logger.info(`Deleting room ${roomName}`)
     try {
       await roomClient.deleteRoom(roomName)
     } catch (error) {

--- a/src/logic/voice/voice.ts
+++ b/src/logic/voice/voice.ts
@@ -65,7 +65,7 @@ export function createVoiceComponent(
         room: getCallIdFromRoomName(roomName),
         address: userAddress
       })
-      await voiceDB.deletePrivateVoiceChat(roomName, userAddress)
+      await voiceDB.deletePrivateVoiceChat(roomName)
       return
     }
 
@@ -130,7 +130,7 @@ export function createVoiceComponent(
    */
   async function endPrivateVoiceChat(roomId: string, address: string): Promise<string[]> {
     const roomName = getPrivateVoiceChatRoomName(roomId)
-    const usersInRoom = await voiceDB.deletePrivateVoiceChat(roomName, address)
+    const usersInRoom = await voiceDB.deletePrivateVoiceChatUserIsOrWasIn(roomName, address)
     await livekit.deleteRoom(roomName)
     return usersInRoom
   }
@@ -146,6 +146,10 @@ export function createVoiceComponent(
         call_id: getCallIdFromRoomName(roomName)
       })
       await livekit.deleteRoom(roomName)
+    }
+
+    if (expiredRoomNames.length > 0) {
+      logger.info(`Deleted ${expiredRoomNames.length} expired private voice chats`)
     }
   }
 

--- a/test/integration/livekit-webhook-handler.spec.ts
+++ b/test/integration/livekit-webhook-handler.spec.ts
@@ -36,11 +36,7 @@ test('POST /livekit-webhook', ({ components, spyComponents }) => {
       })
 
       afterEach(async () => {
-        try {
-          await components.voiceDB.deletePrivateVoiceChat(webhookEvent.room.name, callerAddress)
-        } catch (_e) {
-          // Do nothing if deleting the room fails.
-        }
+        await components.voiceDB.deletePrivateVoiceChat(webhookEvent.room.name)
       })
 
       describe('and the user left voluntarily', () => {
@@ -165,11 +161,7 @@ test('POST /livekit-webhook', ({ components, spyComponents }) => {
       })
 
       afterEach(async () => {
-        try {
-          await components.voiceDB.deletePrivateVoiceChat(webhookEvent.room.name, callerAddress)
-        } catch (_e) {
-          // Do nothing if deleting the room fails.
-        }
+        await components.voiceDB.deletePrivateVoiceChat(webhookEvent.room.name)
       })
 
       describe('and the private room is active', () => {
@@ -189,14 +181,8 @@ test('POST /livekit-webhook', ({ components, spyComponents }) => {
           })
 
           afterEach(async () => {
-            try {
-              await components.voiceDB.deletePrivateVoiceChat(webhookEvent.room.name, calleeAddress)
-            } catch (_e) {
-              // Do nothing if deleting the room fails.
-            } finally {
-              // Restore the room name to the first room.
-              webhookEvent.room.name = oldRoomName
-            }
+            await components.voiceDB.deletePrivateVoiceChat(webhookEvent.room.name)
+            webhookEvent.room.name = oldRoomName
           })
 
           it('should respond with a 200, join the user to the new room, disconnect the user from the old one and delete the old room in livekit', async () => {
@@ -283,7 +269,7 @@ test('POST /livekit-webhook', ({ components, spyComponents }) => {
       describe('and the private room does not exist', () => {
         beforeEach(async () => {
           spyComponents.livekit.deleteRoom.mockResolvedValue(undefined)
-          await components.voiceDB.deletePrivateVoiceChat(webhookEvent.room.name, calleeAddress)
+          await components.voiceDB.deletePrivateVoiceChat(webhookEvent.room.name)
         })
 
         it('should respond with a 200 and delete the livekit room', async () => {

--- a/test/integration/voice-chat/create-private-voice-chat-credentials-handler.spec.ts
+++ b/test/integration/voice-chat/create-private-voice-chat-credentials-handler.spec.ts
@@ -271,14 +271,7 @@ test('POST /private-voice-chat', ({ components, spyComponents }) => {
         })
 
         afterEach(async () => {
-          try {
-            await components.voiceDB.deletePrivateVoiceChat(
-              getPrivateVoiceChatRoomName(requestBody.room_id),
-              requestBody.user_addresses[0]
-            )
-          } catch (error) {
-            // Do nothing
-          }
+          await components.voiceDB.deletePrivateVoiceChat(getPrivateVoiceChatRoomName(requestBody.room_id))
         })
 
         it('should create respond with a 200 and the voice chat credentials', async () => {

--- a/test/integration/voice-chat/delete-private-voice-chat-handler.spec.ts
+++ b/test/integration/voice-chat/delete-private-voice-chat-handler.spec.ts
@@ -176,11 +176,7 @@ test('DELETE /private-voice-chat/:id', ({ components, spyComponents }) => {
         })
 
         afterEach(async () => {
-          try {
-            await components.voiceDB.deletePrivateVoiceChat(roomName, anAddress)
-          } catch (_e) {
-            // Do nothing if deleting the room fails.
-          }
+          await components.voiceDB.deletePrivateVoiceChat(roomName)
         })
 
         describe('and the user is in a voice chat as not connected', () => {

--- a/test/integration/voice-chat/get-voice-status-handler.spec.ts
+++ b/test/integration/voice-chat/get-voice-status-handler.spec.ts
@@ -37,7 +37,7 @@ test('GET /users/:address/voice-chat-status', ({ components, spyComponents }) =>
       })
 
       afterEach(async () => {
-        await components.voiceDB.deletePrivateVoiceChat(roomName, anAddress)
+        await components.voiceDB.deletePrivateVoiceChat(roomName)
       })
 
       describe('and is not expired', () => {
@@ -86,7 +86,7 @@ test('GET /users/:address/voice-chat-status', ({ components, spyComponents }) =>
       })
 
       afterEach(async () => {
-        await components.voiceDB.deletePrivateVoiceChat(roomName, anAddress)
+        await components.voiceDB.deletePrivateVoiceChat(roomName)
       })
 
       describe('and is not expired', () => {
@@ -135,7 +135,7 @@ test('GET /users/:address/voice-chat-status', ({ components, spyComponents }) =>
       })
 
       afterEach(async () => {
-        await components.voiceDB.deletePrivateVoiceChat(roomName, anAddress)
+        await components.voiceDB.deletePrivateVoiceChat(roomName)
       })
 
       it('should respond with a 200 and the property is_user_in_voice_chat as true', async () => {

--- a/test/integration/voice-chat/voice-chat-expiration-job.spec.ts
+++ b/test/integration/voice-chat/voice-chat-expiration-job.spec.ts
@@ -20,13 +20,7 @@ test('when expiring private voice chats', async ({ components, spyComponents }) 
   })
 
   afterEach(async () => {
-    await Promise.all(
-      rooms.map(async (room) =>
-        components.voiceDB.deletePrivateVoiceChat(room.roomName, room.addresses[0]).catch(() => {
-          // Ignore errors
-        })
-      )
-    )
+    await Promise.all(rooms.map(async (room) => components.voiceDB.deletePrivateVoiceChat(room.roomName)))
   })
 
   describe('and there are no expired private voice chats', () => {

--- a/test/mocks/voice-db-mock.ts
+++ b/test/mocks/voice-db-mock.ts
@@ -12,6 +12,7 @@ export const createVoiceDBMockedComponent = (
     isPrivateRoomActive: overrides?.isPrivateRoomActive ?? jest.fn(),
     createVoiceChatRoom: overrides?.createVoiceChatRoom ?? jest.fn(),
     deletePrivateVoiceChat: overrides?.deletePrivateVoiceChat ?? jest.fn(),
+    deletePrivateVoiceChatUserIsOrWasIn: overrides?.deletePrivateVoiceChatUserIsOrWasIn ?? jest.fn(),
     deleteExpiredPrivateVoiceChats: overrides?.deleteExpiredPrivateVoiceChats ?? jest.fn()
   }
 }

--- a/test/unit/voice-logic.spec.ts
+++ b/test/unit/voice-logic.spec.ts
@@ -22,6 +22,9 @@ describe('voice logic component', () => {
   let isPrivateRoomActiveMock: jest.MockedFunction<IVoiceDBComponent['isPrivateRoomActive']>
   let createVoiceChatRoomMock: jest.MockedFunction<IVoiceDBComponent['createVoiceChatRoom']>
   let deletePrivateVoiceChatMock: jest.MockedFunction<IVoiceDBComponent['deletePrivateVoiceChat']>
+  let deletePrivateVoiceChatUserIsOrWasInMock: jest.MockedFunction<
+    IVoiceDBComponent['deletePrivateVoiceChatUserIsOrWasIn']
+  >
   let deleteExpiredPrivateVoiceChatsMock: jest.MockedFunction<IVoiceDBComponent['deleteExpiredPrivateVoiceChats']>
   let logs: jest.Mocked<ILoggerComponent>
 
@@ -37,6 +40,7 @@ describe('voice logic component', () => {
     isPrivateRoomActiveMock = jest.fn()
     createVoiceChatRoomMock = jest.fn()
     deletePrivateVoiceChatMock = jest.fn()
+    deletePrivateVoiceChatUserIsOrWasInMock = jest.fn()
     deleteExpiredPrivateVoiceChatsMock = jest.fn()
 
     livekit = createLivekitMockedComponent({
@@ -55,6 +59,7 @@ describe('voice logic component', () => {
       isPrivateRoomActive: isPrivateRoomActiveMock,
       createVoiceChatRoom: createVoiceChatRoomMock,
       deletePrivateVoiceChat: deletePrivateVoiceChatMock,
+      deletePrivateVoiceChatUserIsOrWasIn: deletePrivateVoiceChatUserIsOrWasInMock,
       deleteExpiredPrivateVoiceChats: deleteExpiredPrivateVoiceChatsMock
     })
 
@@ -156,7 +161,7 @@ describe('voice logic component', () => {
       it('should delete the private voice chat and resolve', async () => {
         await voiceComponent.handleParticipantLeft(userAddress, roomName, disconnectReason)
 
-        expect(deletePrivateVoiceChatMock).toHaveBeenCalledWith(roomName, userAddress)
+        expect(deletePrivateVoiceChatMock).toHaveBeenCalledWith(roomName)
         expect(disconnectUserFromRoomMock).not.toHaveBeenCalled()
         expect(deleteRoomMock).not.toHaveBeenCalled()
         expect(removeUserFromRoomMock).not.toHaveBeenCalled()
@@ -284,14 +289,14 @@ describe('voice logic component', () => {
 
     describe('and the operation succeeds', () => {
       beforeEach(() => {
-        deletePrivateVoiceChatMock.mockResolvedValue(usersInRoom)
+        deletePrivateVoiceChatUserIsOrWasInMock.mockResolvedValue(usersInRoom)
         deleteRoomMock.mockResolvedValue(undefined)
       })
 
       it('should delete the private voice chat, delete the room and return the users that were in the room', async () => {
         const result = await voiceComponent.endPrivateVoiceChat(roomId, userAddress)
 
-        expect(deletePrivateVoiceChatMock).toHaveBeenCalledWith(expectedRoomName, userAddress)
+        expect(deletePrivateVoiceChatUserIsOrWasInMock).toHaveBeenCalledWith(expectedRoomName, userAddress)
         expect(deleteRoomMock).toHaveBeenCalledWith(expectedRoomName)
         expect(result).toEqual(usersInRoom)
       })


### PR DESCRIPTION
This PR does the following:
- Adds some logging to the LiveKit room deletion and expiration process
- Changes the delete function used to remove the DB entries for terminated voice chats due to room destruction to one that does not check if the user has a DB entry or not. This will remove some unnecessary logs about removing a room that was already removed.
- Updates integrations tests to use this new delete function that never throws.