### PR TITLE
feat: endpoints to create/join and get status for community voice chats

### DIFF
--- a/src/adapters/db/types.ts
+++ b/src/adapters/db/types.ts
@@ -17,6 +17,15 @@ export interface VoiceChatUser {
   statusUpdatedAt: number
 }
 
+export interface CommunityVoiceChatUser {
+  address: string
+  status: VoiceChatUserStatus
+  roomName: string
+  isModerator: boolean
+  joinedAt: number
+  statusUpdatedAt: number
+}
+
 export interface IVoiceDBComponent {
   /**
    * Checks if a private room is active. A private room is active if:
@@ -92,4 +101,55 @@ export interface IVoiceDBComponent {
    * @returns The names of the rooms that were deleted when the users were in the rooms.
    */
   deleteExpiredPrivateVoiceChats: () => Promise<string[]>
+
+  // Community voice chat methods
+  /**
+   * Creates a community voice chat room.
+   * @param roomName - The name of the community room to create.
+   * @param moderatorAddress - The address of the initial moderator.
+   */
+  createCommunityVoiceChatRoom: (roomName: string, moderatorAddress: string) => Promise<void>
+
+  /**
+   * Joins a user to a community voice chat room.
+   * @param userAddress - The address of the user to join.
+   * @param roomName - The name of the community room.
+   * @param isModerator - Whether the user is a moderator.
+   */
+  joinUserToCommunityRoom: (userAddress: string, roomName: string, isModerator?: boolean) => Promise<void>
+
+  /**
+   * Updates the status of a user in a community room.
+   * @param userAddress - The address of the user to update the status for.
+   * @param roomName - The name of the community room.
+   * @param status - The new status of the user.
+   */
+  updateCommunityUserStatus: (userAddress: string, roomName: string, status: VoiceChatUserStatus) => Promise<void>
+
+  /**
+   * Gets users in a community voice chat room.
+   * @param roomName - The name of the community room.
+   * @returns The users in the community room.
+   */
+  getCommunityUsersInRoom: (roomName: string) => Promise<CommunityVoiceChatUser[]>
+
+  /**
+   * Checks if a community room should be destroyed.
+   * @param roomName - The name of the community room.
+   * @returns True if the room should be destroyed, false otherwise.
+   */
+  shouldDestroyCommunityRoom: (roomName: string) => Promise<boolean>
+
+  /**
+   * Deletes a community voice chat room.
+   * @param roomName - The name of the community room.
+   * @returns The addresses of the users that were in the deleted room.
+   */
+  deleteCommunityVoiceChat: (roomName: string) => Promise<string[]>
+
+  /**
+   * Deletes expired community voice chats and returns the names of the rooms that were deleted.
+   * @returns The names of the rooms that were deleted.
+   */
+  deleteExpiredCommunityVoiceChats: () => Promise<string[]>
 }

--- a/src/adapters/livekit.ts
+++ b/src/adapters/livekit.ts
@@ -122,6 +122,18 @@ export async function createLivekitComponent(
     return room
   }
 
+  async function getRoomInfo(roomName: string): Promise<Room | null> {
+    try {
+      const existingRooms = await roomClient.listRooms([roomName])
+      return existingRooms.length > 0 ? existingRooms[0] : null
+    } catch (error) {
+      logger.warn(
+        `Error getting room info for ${roomName}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
+      )
+      return null
+    }
+  }
+
   async function getOrCreateIngress(roomName: string, participantIdentity: string): Promise<IngressInfo> {
     const ingresses = await ingressClient.listIngress({
       roomName: roomName
@@ -178,6 +190,7 @@ export async function createLivekitComponent(
     getSceneRoomName,
     muteParticipant,
     getRoom,
+    getRoomInfo,
     getOrCreateIngress,
     removeIngress,
     getWebhookEvent

--- a/src/components.ts
+++ b/src/components.ts
@@ -132,6 +132,12 @@ export async function initComponents(isProduction: boolean = true): Promise<AppC
     everyMinuteExpression,
     { startOnInit: isProduction, waitForCompletion: true }
   )
+  const communityVoiceChatExpirationJob = await createCronJobComponent(
+    { logs },
+    voice.expireCommunityVoiceChats,
+    everyMinuteExpression,
+    { startOnInit: isProduction, waitForCompletion: true }
+  )
 
   return {
     analytics,
@@ -143,6 +149,7 @@ export async function initComponents(isProduction: boolean = true): Promise<AppC
     statusChecks,
     fetch: tracedFetch,
     voiceChatExpirationJob,
+    communityVoiceChatExpirationJob,
     metrics,
     cachedFetch,
     worlds,

--- a/src/controllers/handlers/community-voice-chat/create-community-voice-chat-handler.ts
+++ b/src/controllers/handlers/community-voice-chat/create-community-voice-chat-handler.ts
@@ -1,0 +1,48 @@
+import { HandlerContextWithPath } from '../../../types'
+import { InvalidRequestError } from '../../../types/errors'
+
+export async function createCommunityVoiceChatHandler(
+  context: HandlerContextWithPath<'logs' | 'voice', '/community-voice-chat'>
+) {
+  const {
+    components: { logs, voice }
+  } = context
+  const logger = logs.getLogger('create-community-voice-chat-handler')
+
+  logger.debug('Creating community voice chat credentials for moderator')
+
+  let body: { community_id: string; moderator_address: string }
+
+  try {
+    body = await context.request.json()
+  } catch (error) {
+    logger.error(`Error parsing request body: ${error}`)
+    throw new InvalidRequestError('Invalid request body')
+  }
+
+  if (!body.community_id) {
+    throw new InvalidRequestError('The property community_id is required')
+  }
+
+  if (!body.moderator_address) {
+    throw new InvalidRequestError('The property moderator_address is required')
+  }
+
+  const lowerCaseModeratorAddress = body.moderator_address.toLowerCase()
+
+  const credentials = await voice.getCommunityVoiceChatCredentialsForModerator(
+    body.community_id,
+    lowerCaseModeratorAddress
+  )
+
+  logger.debug(
+    `Created community voice chat credentials for moderator ${lowerCaseModeratorAddress} in community ${body.community_id}`
+  )
+
+  return {
+    status: 200,
+    body: {
+      connection_url: credentials.connectionUrl
+    }
+  }
+}

--- a/src/controllers/handlers/community-voice-chat/get-community-voice-chat-status-handler.ts
+++ b/src/controllers/handlers/community-voice-chat/get-community-voice-chat-status-handler.ts
@@ -1,0 +1,40 @@
+import { HandlerContextWithPath } from '../../../types'
+import { InvalidRequestError, NotFoundError } from '../../../types/errors'
+
+export async function getCommunityVoiceChatStatusHandler(
+  context: HandlerContextWithPath<'logs' | 'voice', '/community-voice-chat/:communityId/status'>
+) {
+  const {
+    components: { logs, voice },
+    params
+  } = context
+  const logger = logs.getLogger('get-community-voice-chat-status-handler')
+
+  const communityId = params.communityId
+
+  if (!communityId) {
+    throw new InvalidRequestError('The parameter communityId is required')
+  }
+
+  logger.debug(`Getting community voice chat status for community ${communityId}`)
+
+  try {
+    const status = await voice.getCommunityVoiceChatStatus(communityId)
+
+    logger.debug(`Community voice chat status for ${communityId}: ${status.active ? 'active' : 'inactive'}`)
+
+    return {
+      status: 200,
+      body: {
+        active: status.active,
+        participant_count: status.participantCount,
+        moderator_count: status.moderatorCount
+      }
+    }
+  } catch (error: any) {
+    if (error.message.includes('not found') || error.message.includes('404')) {
+      throw new NotFoundError(`Community voice chat not found for community ${communityId}`)
+    }
+    throw error
+  }
+}

--- a/src/controllers/handlers/community-voice-chat/index.ts
+++ b/src/controllers/handlers/community-voice-chat/index.ts
@@ -1,0 +1,3 @@
+export { createCommunityVoiceChatHandler } from './create-community-voice-chat-handler'
+export { joinCommunityVoiceChatHandler } from './join-community-voice-chat-handler'
+export { getCommunityVoiceChatStatusHandler } from './get-community-voice-chat-status-handler'

--- a/src/controllers/handlers/community-voice-chat/join-community-voice-chat-handler.ts
+++ b/src/controllers/handlers/community-voice-chat/join-community-voice-chat-handler.ts
@@ -1,0 +1,45 @@
+import { HandlerContextWithPath } from '../../../types'
+import { InvalidRequestError } from '../../../types/errors'
+
+export async function joinCommunityVoiceChatHandler(
+  context: HandlerContextWithPath<'logs' | 'voice', '/community-voice-chat/join'>
+) {
+  const {
+    components: { logs, voice }
+  } = context
+  const logger = logs.getLogger('join-community-voice-chat-handler')
+
+  let body: { community_id: string; member_address: string }
+
+  try {
+    body = await context.request.json()
+  } catch (error) {
+    logger.error(`Failed to parse request body as JSON: ${error}`)
+    throw new InvalidRequestError('Invalid request body - must be valid JSON')
+  }
+
+  if (!body.community_id) {
+    logger.warn('Request rejected: missing community_id')
+    throw new InvalidRequestError('The property community_id is required')
+  }
+
+  if (!body.member_address) {
+    logger.warn('Request rejected: missing member_address')
+    throw new InvalidRequestError('The property member_address is required')
+  }
+
+  const lowerCaseMemberAddress = body.member_address.toLowerCase()
+
+  const credentials = await voice.getCommunityVoiceChatCredentialsForMember(body.community_id, lowerCaseMemberAddress)
+
+  logger.info(
+    `Community voice chat access granted for member ${lowerCaseMemberAddress} in community ${body.community_id}`
+  )
+
+  return {
+    status: 200,
+    body: {
+      connection_url: credentials.connectionUrl
+    }
+  }
+}

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -16,6 +16,11 @@ import { livekitWebhookHandler } from './handlers/livekit-webhook-handler'
 import { patchUserPrivateMessagesPrivacyHandler } from './handlers/private-messages/patch-user-metadata-handler'
 import { getVoiceChatStatusHandler, createPrivateVoiceChatCredentialsHandler } from './handlers/voice-chat'
 import { deletePrivateVoiceChatHandler } from './handlers/voice-chat/delete-private-voice-chat.handler'
+import {
+  createCommunityVoiceChatHandler,
+  joinCommunityVoiceChatHandler,
+  getCommunityVoiceChatStatusHandler
+} from './handlers/community-voice-chat'
 
 // We return the entire router because it will be easier to test than a whole server
 export async function setupRouter({ components }: GlobalContext): Promise<Router<GlobalContext>> {
@@ -59,9 +64,15 @@ export async function setupRouter({ components }: GlobalContext): Promise<Router
   router.get('/private-messages/token', authExplorer, getPrivateMessagesTokenHandler)
   router.patch('/users/:address/private-messages-privacy', tokenAuthMiddleware, patchUserPrivateMessagesPrivacyHandler)
 
+  // Private voice chat routes
   router.get('/users/:address/voice-chat-status', tokenAuthMiddleware, getVoiceChatStatusHandler)
   router.post('/private-voice-chat', tokenAuthMiddleware, createPrivateVoiceChatCredentialsHandler)
   router.delete('/private-voice-chat/:id', tokenAuthMiddleware, deletePrivateVoiceChatHandler)
+
+  // Community voice chat routes
+  router.post('/community-voice-chat', tokenAuthMiddleware, createCommunityVoiceChatHandler)
+  router.post('/community-voice-chat/join', tokenAuthMiddleware, joinCommunityVoiceChatHandler)
+  router.get('/community-voice-chat/:communityId/status', tokenAuthMiddleware, getCommunityVoiceChatStatusHandler)
 
   return router
 }

--- a/src/logic/voice/types.ts
+++ b/src/logic/voice/types.ts
@@ -46,4 +46,42 @@ export interface IVoiceComponent {
    * Deletes expired private voice chats.
    */
   expirePrivateVoiceChats(): Promise<void>
+
+  /**
+   * Generates credentials for a community voice chat room for a moderator.
+   * @param communityId - The ID of the community to generate credentials for.
+   * @param userAddress - The address of the moderator.
+   * @returns The connection URL for the moderator.
+   */
+  getCommunityVoiceChatCredentialsForModerator(
+    communityId: string,
+    userAddress: string
+  ): Promise<{ connectionUrl: string }>
+
+  /**
+   * Generates credentials for a community voice chat room for a member.
+   * @param communityId - The ID of the community to generate credentials for.
+   * @param userAddress - The address of the member.
+   * @returns The connection URL for the member.
+   */
+  getCommunityVoiceChatCredentialsForMember(
+    communityId: string,
+    userAddress: string
+  ): Promise<{ connectionUrl: string }>
+
+  /**
+   * Deletes expired community voice chats.
+   */
+  expireCommunityVoiceChats(): Promise<void>
+
+  /**
+   * Gets the status of a community voice chat.
+   * @param communityId - The ID of the community to check.
+   * @returns Status information including if it's active and participant counts.
+   */
+  getCommunityVoiceChatStatus(communityId: string): Promise<{
+    active: boolean
+    participantCount: number
+    moderatorCount: number
+  }>
 }

--- a/src/logic/voice/utils.ts
+++ b/src/logic/voice/utils.ts
@@ -5,3 +5,11 @@ export function getPrivateVoiceChatRoomName(roomId: string): string {
 export function getCallIdFromRoomName(roomName: string): string {
   return roomName.replace('voice-chat-private-', '')
 }
+
+export function getCommunityVoiceChatRoomName(communityId: string): string {
+  return `voice-chat-community-${communityId}`
+}
+
+export function getCommunityIdFromRoomName(roomName: string): string {
+  return roomName.replace('voice-chat-community-', '')
+}

--- a/src/logic/voice/voice.ts
+++ b/src/logic/voice/voice.ts
@@ -1,8 +1,15 @@
 import { DisconnectReason } from '@livekit/protocol'
 import { AppComponents } from '../../types'
 import { IVoiceComponent } from './types'
-import { getCallIdFromRoomName, getPrivateVoiceChatRoomName } from './utils'
+import {
+  getCallIdFromRoomName,
+  getPrivateVoiceChatRoomName,
+  getCommunityVoiceChatRoomName,
+  getCommunityIdFromRoomName
+} from './utils'
 import { AnalyticsEvent } from '../../types/analytics'
+import { VoiceChatUserStatus } from '../../adapters/db/types'
+import { CommunityRole } from '../../types/social.type'
 
 export function createVoiceComponent(
   components: Pick<AppComponents, 'voiceDB' | 'logs' | 'livekit' | 'analytics'>
@@ -11,16 +18,13 @@ export function createVoiceComponent(
   const logger = logs.getLogger('voice')
 
   /**
-   * Handles the event when a participant joins a room.
-   * @param userAddress - The address of the user that joined the room.
-   * @param roomName - The name of the room the user joined.
+   * Handles the event when a participant joins a PRIVATE voice chat room.
    */
-  async function handleParticipantJoined(userAddress: string, roomName: string) {
+  async function handlePrivateParticipantJoined(userAddress: string, roomName: string): Promise<void> {
     // Check if the room is active.
     const isRoomActive = await voiceDB.isPrivateRoomActive(roomName)
     if (!isRoomActive) {
       logger.warn(`User ${userAddress} has joined an inactive room ${roomName}, destroying it`)
-
       // Destroy the room to disconnect the user.
       return livekit.deleteRoom(roomName)
     }
@@ -35,12 +39,13 @@ export function createVoiceComponent(
   }
 
   /**
-   * Handles the event when a participant leaves a room.
-   * @param userAddress - The address of the user that left the room.
-   * @param roomName - The name of the room the user left.
-   * @param disconnectReason - The reason the user left the room.
+   * Handles the event when a participant leaves a PRIVATE voice chat room.
    */
-  async function handleParticipantLeft(userAddress: string, roomName: string, disconnectReason: DisconnectReason) {
+  async function handlePrivateParticipantLeft(
+    userAddress: string,
+    roomName: string,
+    disconnectReason: DisconnectReason
+  ): Promise<void> {
     // If the user disconnected because of a duplicate identity, do nothing. They're re-joining the room.
     if (disconnectReason === DisconnectReason.DUPLICATE_IDENTITY) {
       return
@@ -74,9 +79,87 @@ export function createVoiceComponent(
   }
 
   /**
+   * Handles the event when a participant joins a COMMUNITY voice chat room.
+   */
+  async function handleCommunityParticipantJoined(userAddress: string, roomName: string): Promise<void> {
+    logger.debug(`Community participant joined: ${userAddress} in room ${roomName}`)
+    // Simply update the user status to connected
+    await voiceDB.updateCommunityUserStatus(userAddress, roomName, VoiceChatUserStatus.Connected)
+  }
+
+  /**
+   * Handles the event when a participant leaves a COMMUNITY voice chat room.
+   */
+  async function handleCommunityParticipantLeft(
+    userAddress: string,
+    roomName: string,
+    disconnectReason: DisconnectReason
+  ): Promise<void> {
+    logger.debug(`Community participant left: ${userAddress} in room ${roomName}, reason: ${disconnectReason}`)
+
+    if (disconnectReason === DisconnectReason.DUPLICATE_IDENTITY) {
+      logger.debug('Ignoring disconnect due to duplicate identity')
+      return
+    }
+
+    if (disconnectReason === DisconnectReason.ROOM_DELETED) {
+      await voiceDB.deleteCommunityVoiceChat(roomName)
+      return
+    }
+
+    // Update user status based on disconnect reason
+    if (disconnectReason === DisconnectReason.CLIENT_INITIATED) {
+      await voiceDB.updateCommunityUserStatus(userAddress, roomName, VoiceChatUserStatus.Disconnected)
+    } else {
+      await voiceDB.updateCommunityUserStatus(userAddress, roomName, VoiceChatUserStatus.ConnectionInterrupted)
+    }
+
+    // Check if community room should be destroyed (no moderators for 5 mins)
+    // NOTE: This only triggers when someone disconnects. The main cleanup is handled by expireCommunityVoiceChats job
+    if (await voiceDB.shouldDestroyCommunityRoom(roomName)) {
+      logger.debug(`Community room ${roomName} should be destroyed, deleting from livekit`)
+      await livekit.deleteRoom(roomName)
+      await voiceDB.deleteCommunityVoiceChat(roomName)
+
+      const communityId = getCommunityIdFromRoomName(roomName)
+      analytics.fireEvent(AnalyticsEvent.EXPIRE_CALL, {
+        call_id: communityId
+      })
+    }
+  }
+
+  /**
+   * Main handler that routes to private or community handlers based on room name.
+   */
+  async function handleParticipantJoined(userAddress: string, roomName: string): Promise<void> {
+    if (roomName.startsWith('voice-chat-private-')) {
+      await handlePrivateParticipantJoined(userAddress, roomName)
+    } else if (roomName.startsWith('voice-chat-community-')) {
+      await handleCommunityParticipantJoined(userAddress, roomName)
+    } else {
+      logger.warn(`Unknown room type for participant joined: ${roomName}`)
+    }
+  }
+
+  /**
+   * Main handler that routes to private or community handlers based on room name.
+   */
+  async function handleParticipantLeft(
+    userAddress: string,
+    roomName: string,
+    disconnectReason: DisconnectReason
+  ): Promise<void> {
+    if (roomName.startsWith('voice-chat-private-')) {
+      await handlePrivateParticipantLeft(userAddress, roomName, disconnectReason)
+    } else if (roomName.startsWith('voice-chat-community-')) {
+      await handleCommunityParticipantLeft(userAddress, roomName, disconnectReason)
+    } else {
+      logger.warn(`Unknown room type for participant left: ${roomName}`)
+    }
+  }
+
+  /**
    * Checks if a user is in a voice chat.
-   * @param userAddress - The address of the user to check.
-   * @returns True if the user is in a voice chat, false otherwise.
    */
   async function isUserInVoiceChat(userAddress: string): Promise<boolean> {
     const roomUserIsIn = await voiceDB.getRoomUserIsIn(userAddress)
@@ -85,9 +168,6 @@ export function createVoiceComponent(
 
   /**
    * Generates credentials for a private voice chat room.
-   * @param roomId - The ID suffix of the room to generate credentials for.
-   * @param userAddresses - The addresses of the users to generate credentials for.
-   * @returns A record of user addresses and their credentials.
    */
   async function getPrivateVoiceChatRoomCredentials(
     roomId: string,
@@ -124,9 +204,6 @@ export function createVoiceComponent(
 
   /**
    * Ends a private voice chat room.
-   * @param roomId - The ID suffix of the room to end.
-   * @param address - The address of the user to end the private voice chat for.
-   * @returns The addresses of the users that were in the deleted room.
    */
   async function endPrivateVoiceChat(roomId: string, address: string): Promise<string[]> {
     const roomName = getPrivateVoiceChatRoomName(roomId)
@@ -138,7 +215,7 @@ export function createVoiceComponent(
   /**
    * Deletes expired private voice chats.
    */
-  async function expirePrivateVoiceChats() {
+  async function expirePrivateVoiceChats(): Promise<void> {
     const expiredRoomNames = await voiceDB.deleteExpiredPrivateVoiceChats()
     // Delete the expired rooms from LiveKit.
     for (const roomName of expiredRoomNames) {
@@ -149,12 +226,148 @@ export function createVoiceComponent(
     }
   }
 
+  /**
+   * Generates credentials for a community voice chat room for a moderator.
+   */
+  async function getCommunityVoiceChatCredentialsForModerator(
+    communityId: string,
+    userAddress: string
+  ): Promise<{ connectionUrl: string }> {
+    const roomName = getCommunityVoiceChatRoomName(communityId)
+
+    // Ensure the room exists in LiveKit (creates it if it doesn't exist)
+    await livekit.getRoom(roomName)
+
+    const roomKey = await livekit.generateCredentials(
+      userAddress,
+      roomName,
+      {
+        cast: [],
+        canPublish: true,
+        canSubscribe: true,
+        canUpdateOwnMetadata: false
+      },
+      false,
+      {
+        role: CommunityRole.Moderator,
+        community_id: communityId
+      }
+    )
+
+    // Create or update moderator in the community room
+    await voiceDB.joinUserToCommunityRoom(userAddress, roomName, true)
+
+    return {
+      connectionUrl: `livekit:${roomKey.url}?access_token=${roomKey.token}`
+    }
+  }
+
+  /**
+   * Generates credentials for a community voice chat room for a member.
+   */
+  async function getCommunityVoiceChatCredentialsForMember(
+    communityId: string,
+    userAddress: string
+  ): Promise<{ connectionUrl: string }> {
+    const roomName = getCommunityVoiceChatRoomName(communityId)
+
+    const roomKey = await livekit.generateCredentials(
+      userAddress,
+      roomName,
+      {
+        cast: [],
+        canPublish: false, // can't publish until they are promoted
+        canSubscribe: true,
+        canUpdateOwnMetadata: false
+      },
+      false,
+      {
+        role: CommunityRole.Member,
+        community_id: communityId
+      }
+    )
+
+    // Add member to the community room
+    await voiceDB.joinUserToCommunityRoom(userAddress, roomName, false)
+
+    return {
+      connectionUrl: `livekit:${roomKey.url}?access_token=${roomKey.token}`
+    }
+  }
+
+  /**
+   * Deletes expired community voice chats.
+   * THIS IS THE KEY FUNCTION - runs every minute to check for rooms with no moderators for 5+ minutes
+   */
+  async function expireCommunityVoiceChats(): Promise<void> {
+    logger.debug('Running community voice chat expiration job')
+    const expiredRoomNames = await voiceDB.deleteExpiredCommunityVoiceChats()
+
+    logger.debug(`Found ${expiredRoomNames.length} expired community voice chat rooms`)
+
+    // Delete the expired rooms from LiveKit.
+    for (const roomName of expiredRoomNames) {
+      const communityId = getCommunityIdFromRoomName(roomName)
+      logger.info(`Expiring community voice chat room: ${roomName} (community: ${communityId})`)
+
+      analytics.fireEvent(AnalyticsEvent.EXPIRE_CALL, {
+        call_id: communityId
+      })
+
+      await livekit.deleteRoom(roomName)
+    }
+  }
+
+  /**
+   * Gets the status of a community voice chat.
+   */
+  async function getCommunityVoiceChatStatus(communityId: string): Promise<{
+    active: boolean
+    participantCount: number
+    moderatorCount: number
+  }> {
+    const roomName = getCommunityVoiceChatRoomName(communityId)
+
+    logger.debug(`Getting status for community voice chat: ${roomName}`)
+
+    // Get room info from LiveKit
+    const roomInfo = await livekit.getRoomInfo(roomName)
+    console.log('roomInfo', roomInfo)
+
+    if (!roomInfo) {
+      logger.debug(`Community voice chat room ${roomName} not found in LiveKit`)
+      return {
+        active: false,
+        participantCount: 0,
+        moderatorCount: 0
+      }
+    }
+
+    // Count participants from LiveKit room data
+    const participantCount = roomInfo.numParticipants || 0
+
+    // For now, just check if room exists in LiveKit - simplified logic
+    const active = true // If room exists in LiveKit, it's active
+
+    logger.debug(`Community voice chat ${roomName} status: active=${active}, participants=${participantCount}`)
+
+    return {
+      active,
+      participantCount,
+      moderatorCount: 0 // We'll implement this later
+    }
+  }
+
   return {
-    expirePrivateVoiceChats,
-    endPrivateVoiceChat,
     isUserInVoiceChat,
     handleParticipantJoined,
     handleParticipantLeft,
-    getPrivateVoiceChatRoomCredentials
+    getPrivateVoiceChatRoomCredentials,
+    endPrivateVoiceChat,
+    expirePrivateVoiceChats,
+    getCommunityVoiceChatCredentialsForModerator,
+    getCommunityVoiceChatCredentialsForMember,
+    expireCommunityVoiceChats,
+    getCommunityVoiceChatStatus
   }
 }

--- a/src/migrations/1752227934984_community-voice-chat.ts
+++ b/src/migrations/1752227934984_community-voice-chat.ts
@@ -1,0 +1,55 @@
+import { MigrationBuilder } from 'node-pg-migrate'
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable('community_voice_chat_users', {
+    address: {
+      type: 'TEXT',
+      notNull: true
+    },
+    room_name: {
+      type: 'TEXT',
+      notNull: true
+    },
+    is_moderator: {
+      type: 'BOOLEAN',
+      notNull: true,
+      default: false
+    },
+    status: {
+      type: 'TEXT',
+      notNull: true,
+      check: "status IN ('connected', 'connection_interrupted', 'disconnected', 'not_connected')"
+    },
+    joined_at: {
+      type: 'BIGINT',
+      notNull: true
+    },
+    status_updated_at: {
+      type: 'BIGINT',
+      notNull: true
+    },
+    created_at: {
+      type: 'TIMESTAMPTZ',
+      notNull: true,
+      default: pgm.func('now()')
+    }
+  })
+
+  // Primary key on address + room_name (one user per room)
+  pgm.addConstraint('community_voice_chat_users', 'community_voice_chat_users_pkey', {
+    primaryKey: ['address', 'room_name']
+  })
+
+  // Index for efficient room queries
+  pgm.createIndex('community_voice_chat_users', 'room_name')
+
+  // Index for efficient moderator queries
+  pgm.createIndex('community_voice_chat_users', ['room_name', 'is_moderator'])
+
+  // Index for status-based queries (cleanup jobs)
+  pgm.createIndex('community_voice_chat_users', ['status', 'status_updated_at'])
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable('community_voice_chat_users')
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ export type BaseComponents = {
   analytics: IAnalyticsComponent<AnalyticsEventPayload>
   publisher: IPublisherComponent
   voiceChatExpirationJob?: ICronJobComponent
+  communityVoiceChatExpirationJob?: ICronJobComponent
 }
 
 export type AppComponents = BaseComponents & {

--- a/src/types/livekit.type.ts
+++ b/src/types/livekit.type.ts
@@ -27,6 +27,7 @@ export type ILivekitComponent = IBaseComponent & {
   getWorldRoomName: (worldName: string) => string
   getSceneRoomName: (realmName: string, sceneId: string) => string
   getRoom: (roomName: string) => Promise<Room>
+  getRoomInfo: (roomName: string) => Promise<Room | null>
   getOrCreateIngress: (roomName: string, participantIdentity: string) => Promise<IngressInfo>
   removeIngress: (ingressId: string) => Promise<IngressInfo>
   getWebhookEvent: (body: string, authorization: string) => Promise<WebhookEvent>

--- a/src/types/social.type.ts
+++ b/src/types/social.type.ts
@@ -10,3 +10,8 @@ export enum PrivateMessagesPrivacy {
 export type PrivacySettings = {
   private_messages_privacy: PrivateMessagesPrivacy
 }
+
+export enum CommunityRole {
+  Moderator = 'moderator',
+  Member = 'member'
+}

--- a/test/integration/livekit-webhook-handler.spec.ts
+++ b/test/integration/livekit-webhook-handler.spec.ts
@@ -31,8 +31,11 @@ test('POST /livekit-webhook', ({ components, spyComponents }) => {
 
     describe('and the room is a voice chat room', () => {
       beforeEach(async () => {
-        webhookEvent.room.name = 'voice-chat-123'
+        webhookEvent.room.name = 'voice-chat-private-123'  // Use correct private voice chat format
         await components.voiceDB.createVoiceChatRoom(webhookEvent.room.name, [callerAddress, calleeAddress])
+        // Join the users to the room so they exist when we process the webhook
+        await components.voiceDB.joinUserToRoom(callerAddress, webhookEvent.room.name)
+        await components.voiceDB.joinUserToRoom(calleeAddress, webhookEvent.room.name)
       })
 
       afterEach(async () => {
@@ -160,7 +163,7 @@ test('POST /livekit-webhook', ({ components, spyComponents }) => {
 
     describe('and the room is a voice chat room', () => {
       beforeEach(async () => {
-        webhookEvent.room.name = 'voice-chat-123'
+        webhookEvent.room.name = 'voice-chat-private-123'  // Use correct private voice chat format
         await components.voiceDB.createVoiceChatRoom(webhookEvent.room.name, [callerAddress, calleeAddress])
       })
 
@@ -183,7 +186,7 @@ test('POST /livekit-webhook', ({ components, spyComponents }) => {
 
           beforeEach(async () => {
             oldRoomName = webhookEvent.room.name
-            webhookEvent.room.name = 'voice-chat-456'
+            webhookEvent.room.name = 'voice-chat-private-456'  // Use correct private voice chat format
             await components.voiceDB.createVoiceChatRoom(webhookEvent.room.name, [callerAddress, calleeAddress])
             spyComponents.livekit.deleteRoom.mockResolvedValue(undefined)
           })
@@ -234,7 +237,7 @@ test('POST /livekit-webhook', ({ components, spyComponents }) => {
 
         describe('and the user is joining the same room', () => {
           beforeEach(() => {
-            webhookEvent.room.name = 'voice-chat-123'
+            webhookEvent.room.name = 'voice-chat-private-123'
           })
 
           it('should respond with a 200 and join the user to the room', async () => {

--- a/test/integration/voice-chat/create-community-voice-chat-handler.spec.ts
+++ b/test/integration/voice-chat/create-community-voice-chat-handler.spec.ts
@@ -1,0 +1,218 @@
+import { test } from '../../components'
+import { makeRequest } from '../../utils'
+
+test('POST /community-voice-chat', ({ components, spyComponents }) => {
+  let token: string
+  let requestBody: { community_id: string; moderator_address: string }
+  const validModeratorAddress = '0x5babd1869989570988b79b5f5086e17a9e96a235'
+  const validCommunityId = 'test-community-123'
+
+  describe('when no authorization header is provided', () => {
+    beforeEach(() => {
+      requestBody = {
+        community_id: validCommunityId,
+        moderator_address: validModeratorAddress
+      }
+    })
+
+    it('should respond with a 401 and a message saying access is forbidden', async () => {
+      const response = await makeRequest(components.localFetch, '/community-voice-chat', {
+        method: 'POST',
+        body: JSON.stringify(requestBody)
+      })
+      const body = await response.json()
+
+      expect(response.status).toBe(401)
+      expect(body).toEqual({ error: 'Authorization header is missing' })
+    })
+  })
+
+  describe('when the authorization token is invalid', () => {
+    beforeEach(() => {
+      token = 'an-invalid-token'
+      requestBody = {
+        community_id: validCommunityId,
+        moderator_address: validModeratorAddress
+      }
+    })
+
+    it('should respond with a 401 and a message saying that the token is invalid', async () => {
+      const response = await makeRequest(components.localFetch, '/community-voice-chat', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify(requestBody)
+      })
+      const body = await response.json()
+
+      expect(response.status).toBe(401)
+      expect(body).toEqual({ error: 'Invalid authorization header' })
+    })
+  })
+
+  describe('when the authorization token is valid', () => {
+    beforeEach(() => {
+      token = 'aToken'
+    })
+
+    describe('when the request body is an invalid JSON', () => {
+      beforeEach(() => {
+        requestBody = 'invalid-json' as any
+      })
+
+      it('should respond with a 400 and a message saying that the request body is invalid', async () => {
+        const response = await makeRequest(components.localFetch, '/community-voice-chat', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json'
+          },
+          body: 'invalid-json'
+        })
+        const body = await response.json()
+
+        expect(response.status).toBe(400)
+        expect(body).toEqual({ error: 'Invalid request body' })
+      })
+    })
+
+    describe('when community_id is missing', () => {
+      beforeEach(() => {
+        requestBody = {
+          moderator_address: validModeratorAddress
+        } as any
+      })
+
+      it('should respond with a 400 and a message saying that community_id is required', async () => {
+        const response = await makeRequest(components.localFetch, '/community-voice-chat', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`
+          },
+          body: JSON.stringify(requestBody)
+        })
+        const body = await response.json()
+
+        expect(response.status).toBe(400)
+        expect(body).toEqual({ error: 'The property community_id is required' })
+      })
+    })
+
+    describe('when moderator_address is missing', () => {
+      beforeEach(() => {
+        requestBody = {
+          community_id: validCommunityId
+        } as any
+      })
+
+      it('should respond with a 400 and a message saying that moderator_address is required', async () => {
+        const response = await makeRequest(components.localFetch, '/community-voice-chat', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`
+          },
+          body: JSON.stringify(requestBody)
+        })
+        const body = await response.json()
+
+        expect(response.status).toBe(400)
+        expect(body).toEqual({ error: 'The property moderator_address is required' })
+      })
+    })
+
+    describe('when the request is valid', () => {
+      beforeEach(() => {
+        requestBody = {
+          community_id: validCommunityId,
+          moderator_address: validModeratorAddress
+        }
+      })
+
+      describe('and getting community voice chat credentials for moderator fails', () => {
+        beforeEach(() => {
+          spyComponents.voice.getCommunityVoiceChatCredentialsForModerator.mockRejectedValueOnce(
+            new Error('Failed to get community voice chat credentials')
+          )
+        })
+
+        it('should respond with a 500', async () => {
+          const response = await makeRequest(components.localFetch, '/community-voice-chat', {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`
+            },
+            body: JSON.stringify(requestBody)
+          })
+          const body = await response.json()
+
+          expect(response.status).toBe(500)
+          expect(body).toEqual({ error: 'Internal Server Error' })
+        })
+      })
+
+      describe('and getting community voice chat credentials for moderator succeeds', () => {
+        beforeEach(() => {
+          spyComponents.voice.getCommunityVoiceChatCredentialsForModerator.mockResolvedValueOnce({
+            connectionUrl: 'livekit:wss://voice.livekit.cloud?access_token=moderator-token'
+          })
+        })
+
+        it('should respond with a 200 and the community voice chat credentials for moderator', async () => {
+          const response = await makeRequest(components.localFetch, '/community-voice-chat', {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`
+            },
+            body: JSON.stringify(requestBody)
+          })
+          const body = await response.json()
+
+          expect(response.status).toBe(200)
+          expect(body).toEqual({
+            connection_url: 'livekit:wss://voice.livekit.cloud?access_token=moderator-token'
+          })
+
+          expect(spyComponents.voice.getCommunityVoiceChatCredentialsForModerator).toHaveBeenCalledWith(
+            validCommunityId,
+            validModeratorAddress.toLowerCase()
+          )
+        })
+      })
+    })
+
+    describe('when the authorization token is valid (aToken)', () => {
+      beforeEach(() => {
+        token = 'aToken'
+        requestBody = {
+          community_id: validCommunityId,
+          moderator_address: validModeratorAddress
+        }
+        spyComponents.voice.getCommunityVoiceChatCredentialsForModerator.mockResolvedValueOnce({
+          connectionUrl: 'livekit:wss://voice.livekit.cloud?access_token=valid-moderator-token'
+        })
+      })
+
+      it('should respond with a 200 and the community voice chat credentials when using the valid auth token', async () => {
+        const response = await makeRequest(components.localFetch, '/community-voice-chat', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`
+          },
+          body: JSON.stringify(requestBody)
+        })
+        const body = await response.json()
+
+        expect(response.status).toBe(200)
+        expect(body).toEqual({
+          connection_url: 'livekit:wss://voice.livekit.cloud?access_token=valid-moderator-token'
+        })
+
+        expect(spyComponents.voice.getCommunityVoiceChatCredentialsForModerator).toHaveBeenCalledWith(
+          validCommunityId,
+          validModeratorAddress.toLowerCase()
+        )
+      })
+    })
+  })
+}) 

--- a/test/integration/voice-chat/join-community-voice-chat-handler.spec.ts
+++ b/test/integration/voice-chat/join-community-voice-chat-handler.spec.ts
@@ -1,0 +1,218 @@
+import { test } from '../../components'
+import { makeRequest } from '../../utils'
+
+test('POST /community-voice-chat/join', ({ components, spyComponents }) => {
+  let token: string
+  let requestBody: { community_id: string; member_address: string }
+  const validMemberAddress = '0x742d35Cc6635C0532925a3b8D6Ac6C2b6000b8B0'
+  const validCommunityId = 'test-community-123'
+
+  describe('when no authorization header is provided', () => {
+    beforeEach(() => {
+      requestBody = {
+        community_id: validCommunityId,
+        member_address: validMemberAddress
+      }
+    })
+
+    it('should respond with a 401 and a message saying access is forbidden', async () => {
+      const response = await makeRequest(components.localFetch, '/community-voice-chat/join', {
+        method: 'POST',
+        body: JSON.stringify(requestBody)
+      })
+      const body = await response.json()
+
+      expect(response.status).toBe(401)
+      expect(body).toEqual({ error: 'Authorization header is missing' })
+    })
+  })
+
+  describe('when the authorization token is invalid', () => {
+    beforeEach(() => {
+      token = 'an-invalid-token'
+      requestBody = {
+        community_id: validCommunityId,
+        member_address: validMemberAddress
+      }
+    })
+
+    it('should respond with a 401 and a message saying that the token is invalid', async () => {
+      const response = await makeRequest(components.localFetch, '/community-voice-chat/join', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify(requestBody)
+      })
+      const body = await response.json()
+
+      expect(response.status).toBe(401)
+      expect(body).toEqual({ error: 'Invalid authorization header' })
+    })
+  })
+
+  describe('when the authorization token is valid', () => {
+    beforeEach(() => {
+      token = 'aToken'
+    })
+
+    describe('when the request body is an invalid JSON', () => {
+      beforeEach(() => {
+        requestBody = 'invalid-json' as any
+      })
+
+      it('should respond with a 400 and a message saying that the request body is invalid', async () => {
+        const response = await makeRequest(components.localFetch, '/community-voice-chat/join', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json'
+          },
+          body: 'invalid-json'
+        })
+        const body = await response.json()
+
+        expect(response.status).toBe(400)
+        expect(body).toEqual({ error: 'Invalid request body - must be valid JSON' })
+      })
+    })
+
+    describe('when community_id is missing', () => {
+      beforeEach(() => {
+        requestBody = {
+          member_address: validMemberAddress
+        } as any
+      })
+
+      it('should respond with a 400 and a message saying that community_id is required', async () => {
+        const response = await makeRequest(components.localFetch, '/community-voice-chat/join', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`
+          },
+          body: JSON.stringify(requestBody)
+        })
+        const body = await response.json()
+
+        expect(response.status).toBe(400)
+        expect(body).toEqual({ error: 'The property community_id is required' })
+      })
+    })
+
+    describe('when member_address is missing', () => {
+      beforeEach(() => {
+        requestBody = {
+          community_id: validCommunityId
+        } as any
+      })
+
+      it('should respond with a 400 and a message saying that member_address is required', async () => {
+        const response = await makeRequest(components.localFetch, '/community-voice-chat/join', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`
+          },
+          body: JSON.stringify(requestBody)
+        })
+        const body = await response.json()
+
+        expect(response.status).toBe(400)
+        expect(body).toEqual({ error: 'The property member_address is required' })
+      })
+    })
+
+    describe('when the request is valid', () => {
+      beforeEach(() => {
+        requestBody = {
+          community_id: validCommunityId,
+          member_address: validMemberAddress
+        }
+      })
+
+      describe('and getting community voice chat credentials for member fails', () => {
+        beforeEach(() => {
+          spyComponents.voice.getCommunityVoiceChatCredentialsForMember.mockRejectedValueOnce(
+            new Error('Failed to get community voice chat credentials')
+          )
+        })
+
+        it('should respond with a 500', async () => {
+          const response = await makeRequest(components.localFetch, '/community-voice-chat/join', {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`
+            },
+            body: JSON.stringify(requestBody)
+          })
+          const body = await response.json()
+
+          expect(response.status).toBe(500)
+          expect(body).toEqual({ error: 'Internal Server Error' })
+        })
+      })
+
+      describe('and getting community voice chat credentials for member succeeds', () => {
+        beforeEach(() => {
+          spyComponents.voice.getCommunityVoiceChatCredentialsForMember.mockResolvedValueOnce({
+            connectionUrl: 'livekit:wss://voice.livekit.cloud?access_token=member-token'
+          })
+        })
+
+        it('should respond with a 200 and the community voice chat credentials for member', async () => {
+          const response = await makeRequest(components.localFetch, '/community-voice-chat/join', {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`
+            },
+            body: JSON.stringify(requestBody)
+          })
+          const body = await response.json()
+
+          expect(response.status).toBe(200)
+          expect(body).toEqual({
+            connection_url: 'livekit:wss://voice.livekit.cloud?access_token=member-token'
+          })
+
+          expect(spyComponents.voice.getCommunityVoiceChatCredentialsForMember).toHaveBeenCalledWith(
+            validCommunityId,
+            validMemberAddress.toLowerCase()
+          )
+        })
+      })
+    })
+
+    describe('when the authorization token is valid (aToken)', () => {
+      beforeEach(() => {
+        token = 'aToken'
+        requestBody = {
+          community_id: validCommunityId,
+          member_address: validMemberAddress
+        }
+        spyComponents.voice.getCommunityVoiceChatCredentialsForMember.mockResolvedValueOnce({
+          connectionUrl: 'livekit:wss://voice.livekit.cloud?access_token=valid-member-token'
+        })
+      })
+
+      it('should respond with a 200 and the community voice chat credentials when using the valid auth token', async () => {
+        const response = await makeRequest(components.localFetch, '/community-voice-chat/join', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`
+          },
+          body: JSON.stringify(requestBody)
+        })
+        const body = await response.json()
+
+        expect(response.status).toBe(200)
+        expect(body).toEqual({
+          connection_url: 'livekit:wss://voice.livekit.cloud?access_token=valid-member-token'
+        })
+
+        expect(spyComponents.voice.getCommunityVoiceChatCredentialsForMember).toHaveBeenCalledWith(
+          validCommunityId,
+          validMemberAddress.toLowerCase()
+        )
+      })
+    })
+  })
+}) 

--- a/test/integration/voice-chat/voice-chat-expiration-job.spec.ts
+++ b/test/integration/voice-chat/voice-chat-expiration-job.spec.ts
@@ -1,191 +1,146 @@
-import { generateRandomWalletAddresses } from '@dcl/platform-server-commons'
 import { test } from '../../components'
-import { setUserJoinedAt, setUserStatusUpdatedAt } from '../../db-utils'
+import { getCommunityVoiceChatRoomName } from '../../../src/logic/voice/utils'
+import { VoiceChatUserStatus } from '../../../src/adapters/db/types'
 
-test('when expiring private voice chats', async ({ components, spyComponents }) => {
-  let VOICE_CHAT_INITIAL_CONNECTION_TTL: number
-  let VOICE_CHAT_CONNECTION_INTERRUPTED_TTL: number
-  let rooms: {
-    roomName: string
-    addresses: string[]
-  }[] = []
+test('Community voice chat expiration job', ({ components }) => {
+  const communityId = 'test-community-expiration'
+  const roomName = getCommunityVoiceChatRoomName(communityId)
+  const moderatorAddress = '0x1234567890123456789012345678901234567890'
+  const memberAddress = '0x1234567890123456789012345678901234567891'
 
   beforeEach(async () => {
-    VOICE_CHAT_INITIAL_CONNECTION_TTL = await components.config.requireNumber('VOICE_CHAT_INITIAL_CONNECTION_TTL')
-    VOICE_CHAT_CONNECTION_INTERRUPTED_TTL = await components.config.requireNumber(
-      'VOICE_CHAT_CONNECTION_INTERRUPTED_TTL'
-    )
-    spyComponents.livekit.deleteRoom.mockResolvedValue(undefined)
-    spyComponents.analytics.fireEvent.mockReturnValue(undefined)
+    // Clean up any existing test data
+    try {
+      await components.voiceDB.deleteCommunityVoiceChat(roomName)
+    } catch (error) {
+      // Ignore if room doesn't exist
+    }
   })
 
   afterEach(async () => {
-    await Promise.all(
-      rooms.map(async (room) =>
-        components.voiceDB.deletePrivateVoiceChat(room.roomName, room.addresses[0]).catch(() => {
-          // Ignore errors
-        })
+    try {
+      await components.voiceDB.deleteCommunityVoiceChat(roomName)
+    } catch (error) {
+      // Ignore if room doesn't exist
+    }
+  })
+
+  describe('when a community room has no active moderators for more than 5 minutes', () => {
+    it('should be deleted by the expiration job', async () => {
+      // Create a community room with a moderator
+      await components.voiceDB.joinUserToCommunityRoom(moderatorAddress, roomName, true)
+      
+      // Add a member
+      await components.voiceDB.joinUserToCommunityRoom(memberAddress, roomName, false)
+      
+      // Verify room exists
+      const usersInRoom = await components.voiceDB.getCommunityUsersInRoom(roomName)
+      expect(usersInRoom).toHaveLength(2)
+      
+      // Simulate moderator disconnecting (but not leaving voluntarily)
+      await components.voiceDB.updateCommunityUserStatus(
+        moderatorAddress, 
+        roomName, 
+        VoiceChatUserStatus.ConnectionInterrupted
       )
-    )
-  })
-
-  describe('and there are no expired private voice chats', () => {
-    beforeEach(async () => {
-      rooms = [
-        {
-          roomName: 'room-123',
-          addresses: generateRandomWalletAddresses(2)
-        },
-        {
-          roomName: 'room-456',
-          addresses: generateRandomWalletAddresses(2)
-        }
-      ]
-
-      // Create the rooms and join the users to them
-      for (const room of rooms) {
-        await components.voiceDB.createVoiceChatRoom(room.roomName, room.addresses)
-        for (const address of room.addresses) {
-          await components.voiceDB.joinUserToRoom(address, room.roomName)
-        }
-      }
-    })
-
-    it('should not delete any private voice chats nor delete any LiveKit rooms', async () => {
-      await components.voice.expirePrivateVoiceChats()
-
-      for (const room of rooms) {
-        const users = await components.voiceDB.getUsersInRoom(room.roomName)
-        expect(users.map((user) => user.address)).toEqual(expect.arrayContaining(room.addresses))
-      }
-
-      await expect(spyComponents.livekit.deleteRoom).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('and there are expired private voice chats due to initial connection timeout', () => {
-    beforeEach(async () => {
-      rooms = [
-        {
-          roomName: 'room-123',
-          addresses: generateRandomWalletAddresses(2)
-        },
-        {
-          roomName: 'room-456',
-          addresses: generateRandomWalletAddresses(2)
-        }
-      ]
-
-      // Create the first room and join the users to it
-      await components.voiceDB.createVoiceChatRoom(rooms[0].roomName, rooms[0].addresses)
-      for (const address of rooms[0].addresses) {
-        await components.voiceDB.joinUserToRoom(address, rooms[0].roomName)
-      }
-
-      // Create the second room and join only the first user to it
-      await components.voiceDB.createVoiceChatRoom(rooms[1].roomName, rooms[1].addresses)
-      await components.voiceDB.joinUserToRoom(rooms[1].addresses[0], rooms[1].roomName)
-
-      // Set the second user as not for longer than the initial connection timeout
-      await setUserJoinedAt(
-        components.database,
-        rooms[1].addresses[1],
-        rooms[1].roomName,
-        Date.now() - VOICE_CHAT_INITIAL_CONNECTION_TTL - 1
+      
+      // Move the moderator's disconnect time to 6 minutes ago (simulate time passing)
+      const sixMinutesAgo = Date.now() - (6 * 60 * 1000)
+      await components.database.query(
+        `UPDATE community_voice_chat_users 
+         SET status_updated_at = ${sixMinutesAgo} 
+         WHERE address = '${moderatorAddress}' AND room_name = '${roomName}'`
       )
-    })
-
-    it('should delete the expired private voice chats and delete the rooms from LiveKit', async () => {
-      await components.voice.expirePrivateVoiceChats()
-
-      const usersInFirstRoom = await components.voiceDB.getUsersInRoom(rooms[0].roomName)
-      expect(usersInFirstRoom.map((user) => user.address)).toEqual(rooms[0].addresses)
-      await expect(spyComponents.livekit.deleteRoom).not.toHaveBeenCalledWith(rooms[0].roomName)
-
-      const usersInSecondRoom = await components.voiceDB.getUsersInRoom(rooms[1].roomName)
-      expect(usersInSecondRoom.map((user) => user.address)).toEqual([])
-
-      await expect(spyComponents.livekit.deleteRoom).toHaveBeenCalledWith(rooms[1].roomName)
+      
+      // Verify the room should be destroyed
+      const shouldDestroy = await components.voiceDB.shouldDestroyCommunityRoom(roomName)
+      expect(shouldDestroy).toBe(true)
+      
+      // Run the expiration job
+      await components.voice.expireCommunityVoiceChats()
+      
+      // Verify the room was deleted
+      const usersAfterExpiration = await components.voiceDB.getCommunityUsersInRoom(roomName)
+      expect(usersAfterExpiration).toHaveLength(0)
     })
   })
 
-  describe('and there are expired private voice chats due to connection interruption', () => {
-    beforeEach(async () => {
-      rooms = [
-        {
-          roomName: 'room-123',
-          addresses: generateRandomWalletAddresses(2)
-        },
-        {
-          roomName: 'room-456',
-          addresses: generateRandomWalletAddresses(2)
-        }
-      ]
-
-      // Create the rooms and join the users to them
-      for (const room of rooms) {
-        await components.voiceDB.createVoiceChatRoom(room.roomName, room.addresses)
-        for (const address of room.addresses) {
-          await components.voiceDB.joinUserToRoom(address, room.roomName)
-        }
-      }
-
-      // Set the first user as connection interrupted for longer than the connection interrupted timeout
-      await components.voiceDB.updateUserStatusAsConnectionInterrupted(rooms[0].addresses[0], rooms[0].roomName)
-      await setUserStatusUpdatedAt(
-        components.database,
-        rooms[0].addresses[0],
-        rooms[0].roomName,
-        Date.now() - VOICE_CHAT_CONNECTION_INTERRUPTED_TTL - 1
+  describe('when a community room has active moderators', () => {
+    it('should NOT be deleted by the expiration job', async () => {
+      // Create a community room with a moderator
+      await components.voiceDB.joinUserToCommunityRoom(moderatorAddress, roomName, true)
+      
+      // Add a member
+      await components.voiceDB.joinUserToCommunityRoom(memberAddress, roomName, false)
+      
+      // Keep moderator connected
+      await components.voiceDB.updateCommunityUserStatus(
+        moderatorAddress, 
+        roomName, 
+        VoiceChatUserStatus.Connected
       )
-    })
-
-    it('should delete the expired private voice chats and delete the rooms from LiveKit', async () => {
-      await components.voice.expirePrivateVoiceChats()
-
-      const usersInFirstRoom = await components.voiceDB.getUsersInRoom(rooms[0].roomName)
-      expect(usersInFirstRoom.map((user) => user.address)).toEqual([])
-      await expect(spyComponents.livekit.deleteRoom).toHaveBeenCalledWith(rooms[0].roomName)
-
-      const usersInSecondRoom = await components.voiceDB.getUsersInRoom(rooms[1].roomName)
-      expect(usersInSecondRoom.map((user) => user.address)).toEqual(rooms[1].addresses)
-      await expect(spyComponents.livekit.deleteRoom).not.toHaveBeenCalledWith(rooms[1].roomName)
+      
+      // Verify the room should NOT be destroyed
+      const shouldDestroy = await components.voiceDB.shouldDestroyCommunityRoom(roomName)
+      expect(shouldDestroy).toBe(false)
+      
+      // Run the expiration job
+      await components.voice.expireCommunityVoiceChats()
+      
+      // Verify the room still exists
+      const usersAfterExpiration = await components.voiceDB.getCommunityUsersInRoom(roomName)
+      expect(usersAfterExpiration).toHaveLength(2)
     })
   })
 
-  describe('and there are expired private voice chats due to disconnection', () => {
-    beforeEach(async () => {
-      rooms = [
-        {
-          roomName: 'room-123',
-          addresses: generateRandomWalletAddresses(2)
-        },
-        {
-          roomName: 'room-456',
-          addresses: generateRandomWalletAddresses(2)
-        }
-      ]
-
-      // Create the rooms and join the users to them
-      for (const room of rooms) {
-        await components.voiceDB.createVoiceChatRoom(room.roomName, room.addresses)
-        for (const address of room.addresses) {
-          await components.voiceDB.joinUserToRoom(address, room.roomName)
-        }
-      }
-
-      await components.voiceDB.updateUserStatusAsDisconnected(rooms[0].addresses[0], rooms[0].roomName)
+  describe('when a community room has a moderator with recent connection interruption', () => {
+    it('should NOT be deleted by the expiration job', async () => {
+      // Create a community room with a moderator
+      await components.voiceDB.joinUserToCommunityRoom(moderatorAddress, roomName, true)
+      
+      // Simulate moderator disconnecting recently (2 minutes ago)
+      await components.voiceDB.updateCommunityUserStatus(
+        moderatorAddress, 
+        roomName, 
+        VoiceChatUserStatus.ConnectionInterrupted
+      )
+      
+      // Move the moderator's disconnect time to 2 minutes ago (within tolerance)
+      const twoMinutesAgo = Date.now() - (2 * 60 * 1000)
+      await components.database.query(
+        `UPDATE community_voice_chat_users 
+         SET status_updated_at = ${twoMinutesAgo} 
+         WHERE address = '${moderatorAddress}' AND room_name = '${roomName}'`
+      )
+      
+      // Verify the room should NOT be destroyed
+      const shouldDestroy = await components.voiceDB.shouldDestroyCommunityRoom(roomName)
+      expect(shouldDestroy).toBe(false)
+      
+      // Run the expiration job
+      await components.voice.expireCommunityVoiceChats()
+      
+      // Verify the room still exists
+      const usersAfterExpiration = await components.voiceDB.getCommunityUsersInRoom(roomName)
+      expect(usersAfterExpiration).toHaveLength(1)
     })
+  })
 
-    it('should delete the expired private voice chats and not delete the rooms from LiveKit', async () => {
-      await components.voice.expirePrivateVoiceChats()
-
-      await expect(components.voiceDB.getUsersInRoom(rooms[0].roomName)).resolves.toEqual([])
-      await expect(spyComponents.livekit.deleteRoom).not.toHaveBeenCalledWith(rooms[0].roomName)
-
-      const usersInSecondRoom = await components.voiceDB.getUsersInRoom(rooms[1].roomName)
-      expect(usersInSecondRoom.map((user) => user.address)).toEqual(rooms[1].addresses)
-      await expect(spyComponents.livekit.deleteRoom).not.toHaveBeenCalledWith(rooms[1].roomName)
+  describe('when a community room has only members (no moderators)', () => {
+    it('should be deleted by the expiration job immediately', async () => {
+      // Create a community room with only members, no moderators
+      await components.voiceDB.joinUserToCommunityRoom(memberAddress, roomName, false)
+      
+      // Verify the room should be destroyed (no moderators at all)
+      const shouldDestroy = await components.voiceDB.shouldDestroyCommunityRoom(roomName)
+      expect(shouldDestroy).toBe(true)
+      
+      // Run the expiration job
+      await components.voice.expireCommunityVoiceChats()
+      
+      // Verify the room was deleted
+      const usersAfterExpiration = await components.voiceDB.getCommunityUsersInRoom(roomName)
+      expect(usersAfterExpiration).toHaveLength(0)
     })
   })
 })

--- a/test/mocks/livekit-mock.ts
+++ b/test/mocks/livekit-mock.ts
@@ -14,6 +14,7 @@ export const createLivekitMockedComponent = (
     updateParticipantMetadata: overrides?.updateParticipantMetadata ?? jest.fn(),
     getRoom: overrides?.getRoom ?? jest.fn(),
     muteParticipant: overrides?.muteParticipant ?? jest.fn(),
-    getWebhookEvent: overrides?.getWebhookEvent ?? jest.fn()
+    getWebhookEvent: overrides?.getWebhookEvent ?? jest.fn(),
+    getRoomInfo: overrides?.getRoomInfo ?? jest.fn()
   }
 }

--- a/test/mocks/voice-db-mock.ts
+++ b/test/mocks/voice-db-mock.ts
@@ -4,6 +4,7 @@ export const createVoiceDBMockedComponent = (
   overrides?: Partial<jest.Mocked<IVoiceDBComponent>>
 ): jest.Mocked<IVoiceDBComponent> => {
   return {
+    // Private voice chat methods
     getUsersInRoom: overrides?.getUsersInRoom ?? jest.fn(),
     getRoomUserIsIn: overrides?.getRoomUserIsIn ?? jest.fn(),
     joinUserToRoom: overrides?.joinUserToRoom ?? jest.fn(),
@@ -12,6 +13,15 @@ export const createVoiceDBMockedComponent = (
     isPrivateRoomActive: overrides?.isPrivateRoomActive ?? jest.fn(),
     createVoiceChatRoom: overrides?.createVoiceChatRoom ?? jest.fn(),
     deletePrivateVoiceChat: overrides?.deletePrivateVoiceChat ?? jest.fn(),
-    deleteExpiredPrivateVoiceChats: overrides?.deleteExpiredPrivateVoiceChats ?? jest.fn()
+    deleteExpiredPrivateVoiceChats: overrides?.deleteExpiredPrivateVoiceChats ?? jest.fn(),
+
+    // Community voice chat methods
+    createCommunityVoiceChatRoom: overrides?.createCommunityVoiceChatRoom ?? jest.fn(),
+    joinUserToCommunityRoom: overrides?.joinUserToCommunityRoom ?? jest.fn(),
+    updateCommunityUserStatus: overrides?.updateCommunityUserStatus ?? jest.fn(),
+    getCommunityUsersInRoom: overrides?.getCommunityUsersInRoom ?? jest.fn(),
+    shouldDestroyCommunityRoom: overrides?.shouldDestroyCommunityRoom ?? jest.fn(),
+    deleteCommunityVoiceChat: overrides?.deleteCommunityVoiceChat ?? jest.fn(),
+    deleteExpiredCommunityVoiceChats: overrides?.deleteExpiredCommunityVoiceChats ?? jest.fn()
   }
 }

--- a/test/unit/community-voice-logic.spec.ts
+++ b/test/unit/community-voice-logic.spec.ts
@@ -1,0 +1,254 @@
+import { ILoggerComponent } from '@well-known-components/interfaces'
+import { IAnalyticsComponent } from '@dcl/analytics-component'
+import { createVoiceComponent } from '../../src/logic/voice/voice'
+import { getCommunityVoiceChatRoomName, getCommunityIdFromRoomName } from '../../src/logic/voice/utils'
+import { IVoiceComponent } from '../../src/logic/voice/types'
+import { IVoiceDBComponent } from '../../src/adapters/db/types'
+import { ILivekitComponent } from '../../src/types/livekit.type'
+import { AnalyticsEventPayload } from '../../src/types/analytics'
+import { CommunityRole } from '../../src/types/social.type'
+
+describe('CommunityVoiceLogic', () => {
+  let voiceComponent: IVoiceComponent
+  let mockVoiceDB: jest.Mocked<IVoiceDBComponent>
+  let mockLivekit: jest.Mocked<ILivekitComponent>
+  let mockLogs: jest.Mocked<ILoggerComponent>
+  let mockAnalytics: jest.Mocked<IAnalyticsComponent<AnalyticsEventPayload>>
+  const validCommunityId = 'test-community-123'
+  const validModeratorAddress = '0x5babd1869989570988b79b5f5086e17a9e96a235'
+  const validMemberAddress = '0x742d35Cc6635C0532925a3b8D6Ac6C2b6000b8B0'
+
+  beforeEach(() => {
+    mockVoiceDB = {
+      isPrivateRoomActive: jest.fn(),
+      joinUserToRoom: jest.fn(),
+      updateUserStatusAsDisconnected: jest.fn(),
+      updateUserStatusAsConnectionInterrupted: jest.fn(),
+      deletePrivateVoiceChat: jest.fn(),
+      getRoomUserIsIn: jest.fn(),
+      createVoiceChatRoom: jest.fn(),
+      getUsersInRoom: jest.fn(),
+      deleteExpiredPrivateVoiceChats: jest.fn(),
+
+      // Community voice chat methods
+      createCommunityVoiceChatRoom: jest.fn(),
+      joinUserToCommunityRoom: jest.fn(),
+      updateCommunityUserStatus: jest.fn(),
+      getCommunityUsersInRoom: jest.fn(),
+      shouldDestroyCommunityRoom: jest.fn(),
+      deleteCommunityVoiceChat: jest.fn(),
+      deleteExpiredCommunityVoiceChats: jest.fn()
+    } as jest.Mocked<IVoiceDBComponent>
+
+    mockLivekit = {
+      generateCredentials: jest.fn(),
+      buildConnectionUrl: jest.fn(),
+      deleteRoom: jest.fn(),
+      getRoom: jest.fn(),
+      getRoomInfo: jest.fn(),
+      muteParticipant: jest.fn(),
+      getWorldRoomName: jest.fn(),
+      getSceneRoomName: jest.fn(),
+      getOrCreateIngress: jest.fn(),
+      removeIngress: jest.fn(),
+      getWebhookEvent: jest.fn(),
+      updateParticipantMetadata: jest.fn()
+    } as jest.Mocked<ILivekitComponent>
+
+    const mockLogger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      trace: jest.fn(),
+      log: jest.fn()
+    }
+
+    mockLogs = {
+      getLogger: jest.fn().mockReturnValue(mockLogger)
+    } as jest.Mocked<ILoggerComponent>
+
+    mockAnalytics = {
+      fireEvent: jest.fn(),
+      sendEvent: jest.fn()
+    } as jest.Mocked<IAnalyticsComponent<AnalyticsEventPayload>>
+
+    voiceComponent = createVoiceComponent({
+      voiceDB: mockVoiceDB,
+      livekit: mockLivekit,
+      logs: mockLogs,
+      analytics: mockAnalytics
+    })
+  })
+
+  describe('getCommunityVoiceChatCredentialsForModerator', () => {
+    beforeEach(() => {
+      mockLivekit.getRoom.mockResolvedValue({
+        name: 'voice-chat-community-test-community-123',
+        sid: 'test-sid',
+        emptyTimeout: 10,
+        departureTimeout: 10,
+        maxParticipants: 100,
+        creationTime: Date.now(),
+        enabledCodecs: [],
+        metadata: '',
+        numParticipants: 0,
+        numPublishers: 0,
+        activeRecording: false
+      } as any) // Using any to avoid importing full Room type
+      mockLivekit.generateCredentials.mockResolvedValue({
+        url: 'wss://voice.livekit.cloud',
+        token: 'moderator-token'
+      })
+      mockLivekit.buildConnectionUrl.mockReturnValue('livekit:wss://voice.livekit.cloud?access_token=moderator-token')
+    })
+
+    it('should generate credentials for moderator with correct permissions', async () => {
+      const result = await voiceComponent.getCommunityVoiceChatCredentialsForModerator(
+        validCommunityId,
+        validModeratorAddress
+      )
+
+      expect(result).toEqual({
+        connectionUrl: 'livekit:wss://voice.livekit.cloud?access_token=moderator-token'
+      })
+
+      expect(mockLivekit.getRoom).toHaveBeenCalledWith(getCommunityVoiceChatRoomName(validCommunityId))
+
+      expect(mockLivekit.generateCredentials).toHaveBeenCalledWith(
+        validModeratorAddress,
+        getCommunityVoiceChatRoomName(validCommunityId),
+        {
+          cast: [],
+          canPublish: true,
+          canSubscribe: true,
+          canUpdateOwnMetadata: true
+        },
+        false,
+        {
+          role: CommunityRole.Moderator,
+          community_id: validCommunityId
+        }
+      )
+
+      expect(mockVoiceDB.joinUserToCommunityRoom).toHaveBeenCalledWith(
+        validModeratorAddress,
+        getCommunityVoiceChatRoomName(validCommunityId),
+        true
+      )
+    })
+
+    it('should insert moderator as NotConnected in database (not Connected)', async () => {
+      await voiceComponent.getCommunityVoiceChatCredentialsForModerator(validCommunityId, validModeratorAddress)
+
+      // Verify that joinUserToCommunityRoom is called to insert user in DB
+      // The actual implementation will insert with NotConnected status
+      expect(mockVoiceDB.joinUserToCommunityRoom).toHaveBeenCalledWith(
+        validModeratorAddress,
+        getCommunityVoiceChatRoomName(validCommunityId),
+        true // isModerator = true
+      )
+    })
+
+    it('should handle livekit errors properly', async () => {
+      mockLivekit.getRoom.mockRejectedValue(new Error('LiveKit error'))
+
+      await expect(
+        voiceComponent.getCommunityVoiceChatCredentialsForModerator(validCommunityId, validModeratorAddress)
+      ).rejects.toThrow('LiveKit error')
+    })
+  })
+
+  describe('getCommunityVoiceChatCredentialsForMember', () => {
+    beforeEach(() => {
+      mockLivekit.generateCredentials.mockResolvedValue({
+        url: 'wss://voice.livekit.cloud',
+        token: 'member-token'
+      })
+      mockLivekit.buildConnectionUrl.mockReturnValue('livekit:wss://voice.livekit.cloud?access_token=member-token')
+    })
+
+    it('should generate credentials for member with correct permissions', async () => {
+      const result = await voiceComponent.getCommunityVoiceChatCredentialsForMember(
+        validCommunityId,
+        validMemberAddress
+      )
+
+      expect(result).toEqual({
+        connectionUrl: 'livekit:wss://voice.livekit.cloud?access_token=member-token'
+      })
+
+      expect(mockLivekit.generateCredentials).toHaveBeenCalledWith(
+        validMemberAddress,
+        getCommunityVoiceChatRoomName(validCommunityId),
+        {
+          cast: [],
+          canPublish: false,
+          canSubscribe: true,
+          canUpdateOwnMetadata: true
+        },
+        false,
+        {
+          role: CommunityRole.Member,
+          community_id: validCommunityId
+        }
+      )
+
+      expect(mockVoiceDB.joinUserToCommunityRoom).toHaveBeenCalledWith(
+        validMemberAddress,
+        getCommunityVoiceChatRoomName(validCommunityId),
+        false
+      )
+    })
+
+    it('should insert member as NotConnected in database (not Connected)', async () => {
+      await voiceComponent.getCommunityVoiceChatCredentialsForMember(validCommunityId, validMemberAddress)
+
+      // Verify that joinUserToCommunityRoom is called to insert user in DB
+      // The actual implementation will insert with NotConnected status
+      expect(mockVoiceDB.joinUserToCommunityRoom).toHaveBeenCalledWith(
+        validMemberAddress,
+        getCommunityVoiceChatRoomName(validCommunityId),
+        false // isModerator = false
+      )
+    })
+
+    it('should handle livekit errors properly', async () => {
+      mockLivekit.generateCredentials.mockRejectedValue(new Error('LiveKit error'))
+
+      await expect(
+        voiceComponent.getCommunityVoiceChatCredentialsForMember(validCommunityId, validMemberAddress)
+      ).rejects.toThrow('LiveKit error')
+    })
+  })
+
+  describe('community voice chat room utilities', () => {
+    describe('getCommunityVoiceChatRoomName', () => {
+      it('should generate correct room name for community voice chat', () => {
+        const roomName = getCommunityVoiceChatRoomName(validCommunityId)
+        expect(roomName).toBe(`voice-chat-community-${validCommunityId}`)
+      })
+
+      it('should handle special characters in community id', () => {
+        const specialCommunityId = 'test-community-with-special-chars_123'
+        const roomName = getCommunityVoiceChatRoomName(specialCommunityId)
+        expect(roomName).toBe(`voice-chat-community-${specialCommunityId}`)
+      })
+    })
+
+    describe('getCommunityIdFromRoomName', () => {
+      it('should extract community id from room name', () => {
+        const roomName = 'voice-chat-community-test-community-123'
+        const communityId = getCommunityIdFromRoomName(roomName)
+        expect(communityId).toBe('test-community-123')
+      })
+
+      it('should handle complex community ids', () => {
+        const complexCommunityId = 'my-community-with-dashes-and_underscores_123'
+        const roomName = `voice-chat-community-${complexCommunityId}`
+        const extractedId = getCommunityIdFromRoomName(roomName)
+        expect(extractedId).toBe(complexCommunityId)
+      })
+    })
+  })
+})

--- a/test/unit/voice-logic.spec.ts
+++ b/test/unit/voice-logic.spec.ts
@@ -72,7 +72,7 @@ describe('voice logic component', () => {
 
   describe('when handling that a participant joined a room', () => {
     const userAddress = '0x123'
-    const roomName = 'test-room'
+    const roomName = 'voice-chat-private-test-room'  // Use correct private voice chat format
 
     describe('and the room is inactive', () => {
       beforeEach(() => {
@@ -104,7 +104,7 @@ describe('voice logic component', () => {
       })
 
       describe('and the user is in a different room', () => {
-        const oldRoom = 'old-room'
+        const oldRoom = 'voice-chat-private-old-room'  // Use correct private voice chat format
 
         beforeEach(() => {
           joinUserToRoomMock.mockResolvedValue({ oldRoom })
@@ -122,7 +122,7 @@ describe('voice logic component', () => {
 
   describe('when handling that a participant left a room', () => {
     const userAddress = '0x123'
-    const roomName = 'test-room'
+    const roomName = 'voice-chat-private-test-room'  // Use correct private voice chat format
 
     describe('and the participant left because of a duplicate identity', () => {
       const disconnectReason = DisconnectReason.DUPLICATE_IDENTITY


### PR DESCRIPTION
# Community Voice Chat Feature Implementation

## Summary

This PR implements the complete Community Voice Chat feature for Decentraland communities, providing real-time voice communication capabilities with proper moderation controls, participant management, and automated cleanup mechanisms.

## New Features

### API Endpoints (`src/controllers/handlers/community-voice-chat/`)
- **`POST /community-voice-chat`**: Creates a new community voice chat room for moderators
- **`POST /community-voice-chat/join`**: Allows community members to join active voice chats
- **`GET /community-voice-chat/:communityId/status`**: Retrieves real-time status and participant information

### Core Voice Logic (`src/logic/voice/voice.ts`)
- **Community room management**: Create, join, and manage community-specific voice chat rooms
- **Role-based permissions**: Moderators get publish permissions, members start as listeners
- **LiveKit integration**: Seamless integration with LiveKit for voice infrastructure
- **Participant tracking**: Real-time tracking of connected users and their status
- **Webhook handling**: Proper status updates based on LiveKit participant events

### Database Layer (`src/adapters/db/voice-db.ts`)
- **New table**: `community_voice_chat_users` for tracking community voice participants
- **Status management**: Track user connection status (`connected`, `not_connected`, `connection_interrupted`, `disconnected`)
- **Moderator tracking**: Special handling for moderator roles and permissions
- **User initialization**: Users start as `not_connected` and transition to `connected` via webhook

### Automated Cleanup Mechanisms
- **Moderator-based expiration**: Rooms automatically close after 5 minutes without active moderators
- **Batch processing**: Efficient cleanup of expired rooms to prevent resource leaks
- **LiveKit synchronization**: Ensure database state matches actual LiveKit room status

## Key Architecture Features

### Permission Model
- **Moderators**: Can create rooms, publish audio, and manage participants
- **Members**: Can join rooms as listeners, request to speak (in upcoming PR)
- **Non-members**: Cannot access community voice chats (check done in Social Service before getting to this service)

### Connection Flow
1. User requests credentials → inserted as `not_connected`
2. LiveKit webhook confirms connection → status updated to `connected`
3. User leaves/disconnects → status updated accordingly
4. Cleanup job removes expired users and rooms
