### PR TITLE
feat: Send the disconnection reason to analytics

### DIFF
--- a/src/controllers/handlers/livekit-webhook-handler.ts
+++ b/src/controllers/handlers/livekit-webhook-handler.ts
@@ -58,7 +58,8 @@ export async function livekitWebhookHandler(
   } else if (event === 'participant_left') {
     analytics.fireEvent(AnalyticsEvent.PARTICIPANT_LEFT_ROOM, {
       room: webhookEvent.room?.name ?? 'Unknown',
-      address: webhookEvent.participant?.identity ?? 'Unknown'
+      address: webhookEvent.participant?.identity ?? 'Unknown',
+      reason: (webhookEvent.participant?.disconnectReason ?? 'Unknown').toString()
     })
 
     if (isVoiceChatRoom && isRoomEventValid(webhookEvent)) {

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -13,6 +13,7 @@ export type AnalyticsEventPayload = {
   [AnalyticsEvent.PARTICIPANT_LEFT_ROOM]: {
     room: string
     address: string
+    reason: string
   }
   [AnalyticsEvent.EXPIRE_CALL]: {
     call_id: string


### PR DESCRIPTION
This PR adds the disconnection reason to the analytics call that send information about LiveKit participants leaving a room.