### PR TITLE
feat: save isSpeaker in Livekit metadata

### DIFF
--- a/src/logic/voice/voice.ts
+++ b/src/logic/voice/voice.ts
@@ -457,7 +457,8 @@ export function createVoiceComponent(
     })
 
     await livekit.updateParticipantMetadata(roomName, userAddress, {
-      isRequestingToSpeak: false
+      isRequestingToSpeak: false,
+      isSpeaker: true
     })
 
     logger.info(`Successfully promoted user ${userAddress} to speaker in community ${communityId}`)
@@ -478,7 +479,8 @@ export function createVoiceComponent(
     })
 
     await livekit.updateParticipantMetadata(roomName, userAddress, {
-      isRequestingToSpeak: false
+      isRequestingToSpeak: false,
+      isSpeaker: false
     })
 
     logger.info(`Successfully demoted user ${userAddress} to listener in community ${communityId}`)

--- a/test/unit/community-voice-logic.spec.ts
+++ b/test/unit/community-voice-logic.spec.ts
@@ -550,7 +550,7 @@ describe('CommunityVoiceLogic', () => {
       expect(mockLivekit.updateParticipantMetadata).toHaveBeenCalledWith(
         getCommunityVoiceChatRoomName(validCommunityId),
         validUserAddress,
-        { isRequestingToSpeak: false }
+        { isRequestingToSpeak: false, isSpeaker: true }
       )
     })
 
@@ -581,7 +581,7 @@ describe('CommunityVoiceLogic', () => {
       expect(mockLivekit.updateParticipantMetadata).toHaveBeenCalledWith(
         getCommunityVoiceChatRoomName(validCommunityId),
         validUserAddress,
-        { isRequestingToSpeak: false }
+        { isRequestingToSpeak: false, isSpeaker: false }
       )
     })
 


### PR DESCRIPTION
Saves `isSpeaker` in Livekit's metadata when promoted and removes it when demoted from speaker. 