### PR TITLE
feat: set isSpeaker in metadata when creating credentials

### DIFF
--- a/src/logic/voice/voice.ts
+++ b/src/logic/voice/voice.ts
@@ -286,7 +286,8 @@ export function createVoiceComponent(
     const roomName = getCommunityVoiceChatRoomName(communityId)
 
     const metadata: CommunityVoiceChatUserMetadata = {
-      role: isModerator ? CommunityRole.Moderator : CommunityRole.Member
+      role: isModerator ? CommunityRole.Moderator : CommunityRole.Member,
+      isSpeaker: isModerator // Moderators are speakers by default
     }
 
     // Add profile data if provided

--- a/src/types/social.type.ts
+++ b/src/types/social.type.ts
@@ -18,6 +18,7 @@ export enum CommunityRole {
 
 export type CommunityVoiceChatUserMetadata = {
   role: CommunityRole
+  isSpeaker?: boolean
 } & CommunityVoiceChatUserProfileMetadata
 
 export type CommunityVoiceChatUserProfile = {

--- a/test/unit/community-voice-logic.spec.ts
+++ b/test/unit/community-voice-logic.spec.ts
@@ -146,6 +146,7 @@ describe('CommunityVoiceLogic', () => {
           false,
           {
             role: CommunityRole.Moderator,
+            isSpeaker: true,
             name: 'TestModerator',
             hasClaimedName: true,
             profilePictureUrl: 'https://example.com/avatar.png'
@@ -189,7 +190,8 @@ describe('CommunityVoiceLogic', () => {
           },
           false,
           {
-            role: CommunityRole.Moderator
+            role: CommunityRole.Moderator,
+            isSpeaker: true
           }
         )
 
@@ -197,6 +199,36 @@ describe('CommunityVoiceLogic', () => {
           validModeratorAddress,
           getCommunityVoiceChatRoomName(validCommunityId),
           true // isModerator = true
+        )
+      })
+    })
+
+    describe('when assigning the metadata to the user', () => {
+      beforeEach(() => {
+        mockLivekit.generateCredentials.mockResolvedValue({
+          url: 'wss://voice.livekit.cloud',
+          token: 'moderator-token'
+        })
+      })
+
+      it('should assign isSpeaker: true by default to moderators', async () => {
+        await voiceComponent.getCommunityVoiceChatCredentialsForModerator(validCommunityId, validModeratorAddress)
+
+        // Verify that the metadata passed to generateCredentials includes isSpeaker: true
+        expect(mockLivekit.generateCredentials).toHaveBeenCalledWith(
+          validModeratorAddress,
+          getCommunityVoiceChatRoomName(validCommunityId),
+          {
+            cast: [],
+            canPublish: true,
+            canSubscribe: true,
+            canUpdateOwnMetadata: false
+          },
+          false,
+          expect.objectContaining({
+            role: CommunityRole.Moderator,
+            isSpeaker: true
+          })
         )
       })
     })
@@ -258,6 +290,7 @@ describe('CommunityVoiceLogic', () => {
           false,
           {
             role: CommunityRole.Member,
+            isSpeaker: false,
             name: 'TestMember',
             hasClaimedName: false,
             profilePictureUrl: 'https://example.com/member-avatar.png'
@@ -301,7 +334,8 @@ describe('CommunityVoiceLogic', () => {
           },
           false,
           {
-            role: CommunityRole.Member
+            role: CommunityRole.Member,
+            isSpeaker: false
           }
         )
 
@@ -309,6 +343,35 @@ describe('CommunityVoiceLogic', () => {
           validMemberAddress,
           getCommunityVoiceChatRoomName(validCommunityId),
           false // isModerator = false
+        )
+      })
+    })
+    describe('when assigning the metadata to the user', () => {
+      beforeEach(() => {
+        mockLivekit.generateCredentials.mockResolvedValue({
+          url: 'wss://voice.livekit.cloud',
+          token: 'member-token'
+        })
+      })
+
+      it('should assign isSpeaker: false by default to members', async () => {
+        await voiceComponent.getCommunityVoiceChatCredentialsForMember(validCommunityId, validMemberAddress)
+
+        // Verify that the metadata passed to generateCredentials includes isSpeaker: false
+        expect(mockLivekit.generateCredentials).toHaveBeenCalledWith(
+          validMemberAddress,
+          getCommunityVoiceChatRoomName(validCommunityId),
+          {
+            cast: [],
+            canPublish: false,
+            canSubscribe: true,
+            canUpdateOwnMetadata: false
+          },
+          false,
+          expect.objectContaining({
+            role: CommunityRole.Member,
+            isSpeaker: false
+          })
         )
       })
     })

--- a/test/unit/voice-logic.spec.ts
+++ b/test/unit/voice-logic.spec.ts
@@ -9,6 +9,7 @@ import { createLivekitMockedComponent } from '../mocks/livekit-mock'
 import { createLoggerMockedComponent } from '../mocks/logger-mock'
 import { createAnalyticsMockedComponent } from '../mocks/analytics-mocks'
 import { VoiceChatUserStatus } from '../../src/adapters/db/types'
+import { CommunityRole } from '../../src/types/social.type'
 
 describe('Voice Logic Component', () => {
   let voiceComponent: IVoiceComponent
@@ -555,7 +556,8 @@ describe('Voice Logic Component', () => {
           },
           false,
           {
-            role: 'moderator'
+            role: CommunityRole.Moderator,
+            isSpeaker: true
           }
         )
         expect(joinUserToCommunityRoomMock).toHaveBeenCalledWith(userAddress, expectedRoomName, true)
@@ -611,7 +613,8 @@ describe('Voice Logic Component', () => {
           },
           false,
           {
-            role: 'member'
+            role: CommunityRole.Member,
+            isSpeaker: false
           }
         )
         expect(joinUserToCommunityRoomMock).toHaveBeenCalledWith(userAddress, expectedRoomName, false)


### PR DESCRIPTION
There's a case where if a user joins and the unity client doesn't know about the room owner, it needs a way to figure out that the owner is a speaker. For that, we need to set the `isSpeaker` to the owner metadata when creating credentials. 