### PR TITLE
feat: Cache deny list and return stale value on failure

### DIFF
--- a/src/adapters/fetch.ts
+++ b/src/adapters/fetch.ts
@@ -3,16 +3,25 @@ import { AppComponents } from '../types'
 import { ICachedFetchComponent } from '../types/fetch.type'
 
 export async function cachedFetchComponent(
-  components: Pick<AppComponents, 'fetch' | 'logs'>
+  components: Pick<AppComponents, 'fetch' | 'logs'>,
+  options?: {
+    max?: number
+    ttl?: number
+    allowStaleOnFetchRejection?: boolean
+  }
 ): Promise<ICachedFetchComponent> {
   const { fetch, logs } = components
+  const max = options?.max ?? 1000
+  const ttl = options?.ttl ?? 1000 * 60 * 5
+  const allowStaleOnFetchRejection = options?.allowStaleOnFetchRejection ?? false
 
   const logger = logs.getLogger('cached-fetch-component')
 
   function cache<T extends object>() {
     return new LRUCache<string, T>({
-      max: 1000,
-      ttl: 1000 * 60 * 5, // 5 min,
+      max,
+      ttl,
+      allowStaleOnFetchRejection,
       fetchMethod: async function (url: string, _staleValue: T | void): Promise<T> {
         try {
           const response = await fetch.fetch(url)

--- a/src/components.ts
+++ b/src/components.ts
@@ -51,7 +51,6 @@ export async function initComponents(isProduction: boolean = true): Promise<AppC
   )
   const statusChecks = await createStatusCheckComponent({ server, config })
   const tracedFetch = createTracedFetchComponent({ tracer })
-  const blockList = await createBlockListComponent({ config, fetch: tracedFetch })
 
   createHttpTracerComponent({ server, tracer })
   instrumentHttpServerWithRequestLogger({ server, logger: logs })
@@ -85,6 +84,10 @@ export async function initComponents(isProduction: boolean = true): Promise<AppC
   const sceneAdminManager = await createSceneAdminManagerComponent({ database, logs })
   const social = await createSocialComponent({ config, logs, fetch: tracedFetch })
   const cachedFetch = await cachedFetchComponent({ fetch: tracedFetch, logs })
+  const cachedFetchWithStale = await cachedFetchComponent(
+    { fetch: tracedFetch, logs },
+    { allowStaleOnFetchRejection: true }
+  )
   const worlds = await createWorldsComponent({ config, logs, cachedFetch })
   const places = await createPlacesComponent({ config, logs, cachedFetch, fetch: tracedFetch })
   const lands = await createLandsComponent({ config, logs, cachedFetch })
@@ -92,6 +95,7 @@ export async function initComponents(isProduction: boolean = true): Promise<AppC
   const landLease = await createLandLeaseComponent({ fetch: tracedFetch, logs })
   const sceneManager = await createSceneManagerComponent({ worlds, lands, sceneAdminManager, landLease })
   const analytics = await createAnalyticsComponent<AnalyticsEventPayload>({ config, logs, fetcher: tracedFetch })
+  const blockList = await createBlockListComponent({ config, cachedFetch: cachedFetchWithStale, logs })
 
   const sceneStreamAccessManager = await createSceneStreamAccessManagerComponent({ database, logs })
 

--- a/test/integration/cached-fetch-component.spec.ts
+++ b/test/integration/cached-fetch-component.spec.ts
@@ -1,87 +1,138 @@
 import { cachedFetchComponent } from '../../src/adapters/fetch'
+import { createLoggerMockedComponent } from '../mocks/logger-mock'
 
-describe('CachedFetchComponent', () => {
-  let cachedComponent: Awaited<ReturnType<typeof cachedFetchComponent>>
-  let mockNodeFetch: jest.Mock
+let cachedComponent: Awaited<ReturnType<typeof cachedFetchComponent>>
+let mockNodeFetch: jest.Mock
+let cachedFunction: ReturnType<typeof cachedComponent.cache>
+let fetchingUrl: string
+let mockedResponseBody: { data: string }
 
-  beforeEach(async () => {
-    jest.clearAllMocks()
+beforeEach(async () => {
+  fetchingUrl = 'https://test-url.com'
+  mockNodeFetch = jest.fn()
+  const mockFetch = {
+    fetch: mockNodeFetch
+  }
 
-    mockNodeFetch = jest.fn()
+  const mockLogs = createLoggerMockedComponent()
+  cachedComponent = await cachedFetchComponent({
+    fetch: mockFetch,
+    logs: mockLogs
+  })
+  cachedFunction = cachedComponent.cache()
+  mockedResponseBody = { data: 'test data' }
+})
 
-    const mockFetch = {
-      fetch: mockNodeFetch
-    }
-
-    const mockLogs = {
-      getLogger: jest.fn().mockReturnValue({
-        log: jest.fn(),
-        info: jest.fn(),
-        debug: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn()
-      })
-    }
-
-    cachedComponent = await cachedFetchComponent({
-      fetch: mockFetch,
-      logs: mockLogs
+describe('when fetching a URL for the first time', () => {
+  beforeEach(() => {
+    mockNodeFetch.mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockedResponseBody)
     })
   })
 
-  describe('cache function', () => {
-    it('should cache fetch responses', async () => {
-      const mockResponse = { data: 'test data' }
-      mockNodeFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValue(mockResponse)
-      })
+  it('should resolve with the fetched response data and call the underlying fetch function', async () => {
+    const result = await cachedFunction.fetch(fetchingUrl)
+    expect(result).toEqual(mockedResponseBody)
+    expect(mockNodeFetch).toHaveBeenCalledWith(fetchingUrl)
+  })
+})
 
-      const cachedFunction = cachedComponent.cache()
-      await cachedFunction.set('https://test-url.com', undefined)
-      const result = await cachedFunction.fetch('https://test-url.com')
+describe('when fetching the same URL multiple times', () => {
+  beforeEach(() => {
+    mockNodeFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValueOnce(mockedResponseBody)
+    })
+  })
 
-      expect(result).toEqual(mockResponse)
-      expect(mockNodeFetch).toHaveBeenCalledWith('https://test-url.com')
+  it('should resolve with the same response data for both requests', async () => {
+    const result1 = await cachedFunction.fetch(fetchingUrl)
+    const result2 = await cachedFunction.fetch(fetchingUrl)
+
+    expect(result1).toEqual(mockedResponseBody)
+    expect(result2).toEqual(mockedResponseBody)
+  })
+
+  it('should call the underlying fetch function only once with the correct URL', async () => {
+    await cachedFunction.fetch(fetchingUrl)
+    await cachedFunction.fetch(fetchingUrl)
+
+    expect(mockNodeFetch).toHaveBeenCalledTimes(1)
+    expect(mockNodeFetch).toHaveBeenCalledWith(fetchingUrl)
+  })
+})
+
+describe('when the fetch operation fails', () => {
+  beforeEach(() => {
+    const mockError = new Error('Fetch error')
+    mockNodeFetch.mockRejectedValueOnce(mockError)
+  })
+
+  describe('and the stale value on rejection flag is set to false', () => {
+    it('should reject with the fetch error', async () => {
+      await expect(cachedFunction.fetch(fetchingUrl)).rejects.toThrow('Fetch error')
+    })
+  })
+
+  describe('and the stale value on rejection flag is set to true', () => {
+    beforeEach(async () => {
+      cachedComponent = await cachedFetchComponent(
+        {
+          fetch: {
+            fetch: mockNodeFetch
+          },
+          logs: createLoggerMockedComponent()
+        },
+        { allowStaleOnFetchRejection: true }
+      )
+      cachedFunction = cachedComponent.cache()
+      await cachedFunction.set(fetchingUrl, mockedResponseBody)
     })
 
-    it('should reuse cached results for repeated requests', async () => {
-      const mockResponse = { data: 'test data' }
-      mockNodeFetch.mockResolvedValue({
-        ok: true,
-        json: jest.fn().mockResolvedValue(mockResponse)
-      })
+    it('should resolve with the stale value', async () => {
+      const result = await cachedFunction.fetch(fetchingUrl)
+      expect(result).toEqual(mockedResponseBody)
+    })
+  })
+})
 
-      const cachedFunction = cachedComponent.cache()
+describe('when the response is not ok', () => {
+  beforeEach(() => {
+    mockNodeFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found'
+    })
+  })
 
-      const result1 = await cachedFunction.fetch('https://test-url.com')
-      expect(result1).toEqual(mockResponse)
-      expect(mockNodeFetch).toHaveBeenCalledTimes(1)
+  describe('and the stale value on rejection flag is set to false', () => {
+    it('should throw an error with the URL in the message', async () => {
+      await expect(cachedFunction.fetch(fetchingUrl)).rejects.toThrow(`Error getting ${fetchingUrl}`)
+    })
+  })
 
-      const result2 = await cachedFunction.fetch('https://test-url.com')
-      expect(result2).toEqual(mockResponse)
+  describe('and the stale value on rejection flag is set to true', () => {
+    let staleData: any
 
-      expect(mockNodeFetch).toHaveBeenCalledTimes(1)
-      expect(mockNodeFetch).toHaveBeenCalledWith('https://test-url.com')
+    beforeEach(async () => {
+      cachedComponent = await cachedFetchComponent(
+        {
+          fetch: {
+            fetch: mockNodeFetch
+          },
+          logs: createLoggerMockedComponent()
+        },
+        { allowStaleOnFetchRejection: true }
+      )
+      cachedFunction = cachedComponent.cache()
+      staleData = await cachedFunction.set(fetchingUrl, mockedResponseBody)
+      mockNodeFetch.mockRejectedValueOnce(new Error('Fetch error'))
     })
 
-    it('should handle fetch errors', async () => {
-      const mockError = new Error('Fetch error')
-      mockNodeFetch.mockRejectedValueOnce(mockError)
-
-      const cachedFunction = cachedComponent.cache()
-      await expect(cachedFunction.fetch('https://test-url.com')).rejects.toThrow('Fetch error')
-    })
-
-    it('should handle non-ok responses', async () => {
-      mockNodeFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-        statusText: 'Not Found'
-      })
-
-      const cachedFunction = cachedComponent.cache()
-      await expect(cachedFunction.fetch('https://test-url.com')).rejects.toThrow('Error getting https://test-url.com')
+    it('should return the stale value', async () => {
+      const result = await cachedFunction.fetch(fetchingUrl)
+      expect(result).toEqual(mockedResponseBody)
     })
   })
 })

--- a/test/integration/cached-fetch-component.spec.ts
+++ b/test/integration/cached-fetch-component.spec.ts
@@ -40,7 +40,7 @@ describe('when fetching a URL for the first time', () => {
 
 describe('when fetching the same URL multiple times', () => {
   beforeEach(() => {
-    mockNodeFetch.mockResolvedValue({
+    mockNodeFetch.mockResolvedValueOnce({
       ok: true,
       json: jest.fn().mockResolvedValueOnce(mockedResponseBody)
     })

--- a/test/mocks/cached-fetch.ts
+++ b/test/mocks/cached-fetch.ts
@@ -1,0 +1,12 @@
+import { ICachedFetchComponent } from '../../src/types/fetch.type'
+
+export const createCachedFetchMockedComponent = (
+  overrides?: Partial<jest.Mocked<Pick<ReturnType<ICachedFetchComponent['cache']>, 'fetch'>>>
+): jest.Mocked<ICachedFetchComponent> => {
+  return {
+    cache: jest.fn().mockImplementation(() => ({
+      fetch: jest.fn(),
+      ...overrides
+    }))
+  } as jest.Mocked<ICachedFetchComponent>
+}


### PR DESCRIPTION
This PR changes the behavior on how we're fetching the deny list by caching the result of the deny list request. This also allows us to return the stale result value on failure.
This change will will the comms-gatekeeper never fail when there's no deny list.