### PR TITLE
feat: Publish the user left room event when the user leaves a scene room

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@dcl/crypto": "^3.4.5",
     "@dcl/platform-crypto-middleware": "^1.1.0",
     "@dcl/platform-server-commons": "^0.2.0",
-    "@dcl/schemas": "^16.8.0",
+    "@dcl/schemas": "^18.5.1",
     "@well-known-components/env-config-provider": "^1.1.1",
     "@well-known-components/fetch-component": "^3.0.0",
     "@well-known-components/http-requests-logger-component": "^2.1.0",

--- a/src/components.ts
+++ b/src/components.ts
@@ -177,7 +177,9 @@ export async function initComponents(isProduction: boolean = true): Promise<AppC
   const participantLeftHandler = createParticipantLeftHandler({
     voice,
     analytics,
-    logs
+    logs,
+    livekit,
+    publisher
   })
   const roomStartedHandler = createRoomStartedHandler({
     livekit,

--- a/src/logic/livekit-webhook/event-handlers/participant-left-handler.ts
+++ b/src/logic/livekit-webhook/event-handlers/participant-left-handler.ts
@@ -1,3 +1,4 @@
+import { Events, UserLeftRoomEvent } from '@dcl/schemas'
 import { WebhookEvent } from 'livekit-server-sdk'
 import { ILivekitWebhookEventHandler, WebhookEventName } from './types'
 import { AppComponents } from '../../../types'
@@ -5,22 +6,55 @@ import { AnalyticsEvent } from '../../../types/analytics'
 import { isRoomEventValid, isVoiceChatRoom } from './utils'
 
 export function createParticipantLeftHandler(
-  components: Pick<AppComponents, 'voice' | 'analytics' | 'logs'>
+  components: Pick<AppComponents, 'voice' | 'analytics' | 'logs' | 'livekit' | 'publisher'>
 ): ILivekitWebhookEventHandler {
   const logger = components.logs.getLogger('participant-left-handler')
 
   return {
     eventName: WebhookEventName.PARTICIPANT_LEFT,
     handle: async (webhookEvent: WebhookEvent) => {
+      // Check if the room and participant data are valid
+      if (!isRoomEventValid(webhookEvent)) {
+        return
+      }
+
       const { room, participant } = webhookEvent
+      const { sceneId, worldName, realmName } = components.livekit.getSceneRoomMetadataFromRoomName(room.name)
+
+      // Only emit the user left room event if the room is a scene or world room
+      if (sceneId || worldName) {
+        const event: UserLeftRoomEvent = {
+          type: Events.Type.COMMS,
+          subType: Events.SubType.Comms.USER_LEFT_ROOM,
+          key: `user-left-room-${room.name}`,
+          timestamp: Date.now(),
+          metadata: {
+            sceneId: sceneId,
+            userAddress: participant.identity.toLowerCase(),
+            isWorld: worldName ? true : false,
+            realmName: worldName || realmName || ''
+          }
+        }
+
+        try {
+          await components.publisher.publishMessages([event])
+          logger.debug(`Published UserJoinedRoomEvent for ${participant.identity} in room ${room}`)
+        } catch (error: any) {
+          logger.error(`Failed to publish UserJoinedRoomEvent: ${error}`, {
+            error,
+            event: JSON.stringify(event),
+            room: room.name
+          })
+        }
+      }
 
       components.analytics.fireEvent(AnalyticsEvent.PARTICIPANT_LEFT_ROOM, {
-        room: room?.name ?? 'Unknown',
-        address: participant?.identity ?? 'Unknown',
-        reason: (participant?.disconnectReason ?? 'Unknown').toString()
+        room: room.name,
+        address: participant.identity,
+        reason: participant.disconnectReason.toString()
       })
 
-      if (isVoiceChatRoom(webhookEvent) && isRoomEventValid(webhookEvent)) {
+      if (isVoiceChatRoom(webhookEvent)) {
         const disconnectReason = webhookEvent.participant.disconnectReason
         logger.debug(
           `Participant ${webhookEvent.participant.identity} left voice chat room ${webhookEvent.room.name} with reason ${disconnectReason}`

--- a/test/integration/livekit-webhook-handler.spec.ts
+++ b/test/integration/livekit-webhook-handler.spec.ts
@@ -30,11 +30,13 @@ test('POST /livekit-webhook', ({ components, spyComponents }) => {
     // Set up spies for voice component methods but preserve original implementation
     handleParticipantJoinedSpy = jest.spyOn(components.voice, 'handleParticipantJoined')
     handleParticipantLeftSpy = jest.spyOn(components.voice, 'handleParticipantLeft')
+    spyComponents.publisher.publishMessages.mockReturnValue(undefined)
   })
 
   afterEach(() => {
     handleParticipantJoinedSpy?.mockRestore()
     handleParticipantLeftSpy?.mockRestore()
+    spyComponents.publisher.publishMessages.mockRestore()
   })
 
   describe('when the event is a participant left event', () => {

--- a/test/mocks/publisher-mock.ts
+++ b/test/mocks/publisher-mock.ts
@@ -1,0 +1,10 @@
+import { IPublisherComponent } from '../../src/types'
+
+export const createPublisherMockedComponent = (
+  overrides?: Partial<jest.Mocked<IPublisherComponent>>
+): jest.Mocked<IPublisherComponent> => {
+  return {
+    publishMessages: jest.fn(),
+    ...overrides
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -793,10 +793,20 @@
     ajv-keywords "^5.1.0"
     mitt "^3.0.1"
 
-"@dcl/schemas@^16.8.0", "@dcl/schemas@^16.9.0":
+"@dcl/schemas@^16.9.0":
   version "16.9.0"
   resolved "https://registry.npmjs.org/@dcl/schemas/-/schemas-16.9.0.tgz"
   integrity sha512-YmYb2QvdOr5AdCzRsmlv3iT2KGnJ9jRqMVF7aMSgqOBcqCXuNsXZ28dQh3wnsNkmTR+xom4YIMJbkQTkKeoSXA==
+  dependencies:
+    ajv "^8.11.0"
+    ajv-errors "^3.0.0"
+    ajv-keywords "^5.1.0"
+    mitt "^3.0.1"
+
+"@dcl/schemas@^18.5.1":
+  version "18.5.1"
+  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-18.5.1.tgz#e56614c21dc374acb9e0135dffc778e6e3ec9c30"
+  integrity sha512-tGJ6h4OpyviSWnAbAnHzEdA7CUq5eUwD3tNQndSbmpszpPDGq7WjIs8YE5cV16TUBuhKx9HzJZqs0z+ls8USXw==
   dependencies:
     ajv "^8.11.0"
     ajv-errors "^3.0.0"


### PR DESCRIPTION
When a user leaves a scene or world LiveKit room, publish a SNS event so we can capture it in the credits-server and act upon it.

Closes #130 