### PR TITLE
feat: Move the UserJoinedRoomEvent to the participant joined event handler

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -189,7 +189,9 @@ export async function initComponents(isProduction: boolean = true): Promise<AppC
   const participantJoinedHandler = createParticipantJoinedHandler({
     voice,
     analytics,
-    logs
+    logs,
+    livekit,
+    publisher
   })
   const participantLeftHandler = createParticipantLeftHandler({
     voice,

--- a/src/controllers/handlers/comms-scene-handler.ts
+++ b/src/controllers/handlers/comms-scene-handler.ts
@@ -1,4 +1,3 @@
-import { Events, UserJoinedRoomEvent } from '@dcl/schemas'
 import { IHttpServerComponent } from '@well-known-components/interfaces'
 import { HandlerContextWithPath, Permissions } from '../../types'
 import { ForbiddenError, InvalidRequestError, NotFoundError, UnauthorizedError } from '../../types/errors'
@@ -9,12 +8,12 @@ const PREVIEW = 'preview'
 
 export async function commsSceneHandler(
   context: HandlerContextWithPath<
-    'fetch' | 'config' | 'livekit' | 'logs' | 'blockList' | 'publisher' | 'sceneBans' | 'places',
+    'fetch' | 'config' | 'livekit' | 'logs' | 'blockList' | 'sceneBans' | 'places',
     '/get-scene-adapter'
   >
 ): Promise<IHttpServerComponent.IResponse> {
   const {
-    components: { livekit, logs, blockList, publisher, sceneBans }
+    components: { livekit, logs, blockList, sceneBans }
   } = context
 
   const logger = logs.getLogger('comms-scene-handler')
@@ -88,33 +87,6 @@ export async function commsSceneHandler(
 
   const credentials = await livekit.generateCredentials(identity, room, permissions, forPreview)
   logger.debug(`Token generated for ${identity} to join room ${room}`)
-
-  setImmediate(async () => {
-    const event: UserJoinedRoomEvent = {
-      type: Events.Type.COMMS,
-      subType: Events.SubType.Comms.USER_JOINED_ROOM,
-      key: `user-joined-room-${room}`,
-      timestamp: Date.now(),
-      metadata: {
-        sceneId: sceneId || '',
-        userAddress: identity.toLowerCase(),
-        parcel,
-        realmName,
-        isWorld
-      }
-    }
-
-    try {
-      await publisher.publishMessages([event])
-      logger.debug(`Published UserJoinedRoomEvent for ${identity} in room ${room}`)
-    } catch (error: any) {
-      logger.error(`Failed to publish UserJoinedRoomEvent: ${error}`, {
-        error,
-        event: JSON.stringify(event),
-        room
-      })
-    }
-  })
 
   return {
     status: 200,

--- a/src/logic/livekit-webhook/event-handlers/participant-joined-handler.ts
+++ b/src/logic/livekit-webhook/event-handlers/participant-joined-handler.ts
@@ -3,27 +3,61 @@ import { ILivekitWebhookEventHandler, WebhookEventName } from './types'
 import { AppComponents } from '../../../types'
 import { AnalyticsEvent } from '../../../types/analytics'
 import { isRoomEventValid, isVoiceChatRoom } from './utils'
+import { Events } from '@dcl/schemas'
+import { UserJoinedRoomEvent } from '@dcl/schemas'
 
 export function createParticipantJoinedHandler(
-  components: Pick<AppComponents, 'voice' | 'analytics' | 'logs'>
+  components: Pick<AppComponents, 'voice' | 'analytics' | 'logs' | 'livekit' | 'publisher'>
 ): ILivekitWebhookEventHandler {
   const logger = components.logs.getLogger('participant-joined-handler')
 
   return {
     eventName: WebhookEventName.PARTICIPANT_JOINED,
     handle: async (webhookEvent: WebhookEvent) => {
+      // Check if the room and participant data are valid
+      if (!isRoomEventValid(webhookEvent)) {
+        return
+      }
       const { room, participant } = webhookEvent
 
+      const address = participant.identity.toLowerCase()
+      const { sceneId, worldName, realmName } = components.livekit.getSceneRoomMetadataFromRoomName(room.name)
+
+      if (sceneId || worldName) {
+        const event: UserJoinedRoomEvent = {
+          type: Events.Type.COMMS,
+          subType: Events.SubType.Comms.USER_JOINED_ROOM,
+          key: `user-joined-room-${room.name}`,
+          timestamp: Date.now(),
+          metadata: {
+            sceneId: sceneId ?? '',
+            userAddress: address,
+            parcel: '',
+            realmName: worldName ?? realmName ?? '',
+            isWorld: !!worldName
+          }
+        }
+
+        try {
+          await components.publisher.publishMessages([event])
+          logger.debug(`Published UserJoinedRoomEvent for ${address} in room ${room.name}`)
+        } catch (error: any) {
+          logger.error(`Failed to publish UserJoinedRoomEvent: ${error}`, {
+            error,
+            event: JSON.stringify(event),
+            room: room.name
+          })
+        }
+      }
+
       components.analytics.fireEvent(AnalyticsEvent.PARTICIPANT_JOINED_ROOM, {
-        room: room?.name ?? 'Unknown',
-        address: participant?.identity ?? 'Unknown'
+        room: room.name,
+        address
       })
 
-      if (isVoiceChatRoom(webhookEvent) && isRoomEventValid(webhookEvent)) {
-        logger.debug(
-          `Participant ${webhookEvent.participant.identity} joined voice chat room ${webhookEvent.room.name}`
-        )
-        await components.voice.handleParticipantJoined(webhookEvent.participant.identity, webhookEvent.room.name)
+      if (isVoiceChatRoom(webhookEvent)) {
+        logger.debug(`Participant ${address} joined voice chat room ${room.name}`)
+        await components.voice.handleParticipantJoined(address, room.name)
       }
     }
   }

--- a/src/logic/livekit-webhook/event-handlers/participant-left-handler.ts
+++ b/src/logic/livekit-webhook/event-handlers/participant-left-handler.ts
@@ -31,16 +31,16 @@ export function createParticipantLeftHandler(
           metadata: {
             sceneId: sceneId,
             userAddress: participant.identity.toLowerCase(),
-            isWorld: worldName ? true : false,
+            isWorld: !!worldName,
             realmName: worldName || realmName || ''
           }
         }
 
         try {
           await components.publisher.publishMessages([event])
-          logger.debug(`Published UserJoinedRoomEvent for ${participant.identity} in room ${room}`)
+          logger.debug(`Published UserLeftRoomEvent for ${participant.identity} in room ${room}`)
         } catch (error: any) {
-          logger.error(`Failed to publish UserJoinedRoomEvent: ${error}`, {
+          logger.error(`Failed to publish UserLeftRoomEvent: ${error}`, {
             error,
             event: JSON.stringify(event),
             room: room.name

--- a/test/integration/comms-server-scene-handler.spec.ts
+++ b/test/integration/comms-server-scene-handler.spec.ts
@@ -40,10 +40,6 @@ test('POST /get-server-scene-adapter', ({ components, stubComponents }) => {
       token: 'mock-token'
     })
     stubComponents.livekit.buildConnectionUrl.returns('wss://livekit.example.com?token=mock-token')
-    stubComponents.publisher.publishMessages.resolves({
-      successfulMessageIds: ['msg-1'],
-      failedEvents: []
-    })
   })
 
   afterEach(() => {


### PR DESCRIPTION
This PR moves the `UserJoinedRoomEvent` from the `comms-scene-handler` to the participant joined handler, making it more precise on when the user joined the room.