### PR TITLE
fix: generate ingress_id for dcl new cast access as well

### DIFF
--- a/test/unit/cast/build-stream-links.spec.ts
+++ b/test/unit/cast/build-stream-links.spec.ts
@@ -1,0 +1,58 @@
+import { buildStreamLinks } from '../../../src/logic/cast/cast'
+
+describe('buildStreamLinks', () => {
+  describe('when building stream and watcher links', () => {
+    let cast2BaseUrl: string
+    let streamingKey: string
+    let location: string
+
+    beforeEach(() => {
+      cast2BaseUrl = 'https://cast2.decentraland.org'
+      streamingKey = 'cast2-link-abc123'
+      location = '10,20'
+    })
+
+    it('should build correct stream link with parcel location', () => {
+      const result = buildStreamLinks(cast2BaseUrl, streamingKey, location)
+
+      expect(result.streamLink).toBe('https://cast2.decentraland.org/s/cast2-link-abc123')
+      expect(result.watcherLink).toBe('https://cast2.decentraland.org/w/10,20')
+    })
+
+    it('should build correct links with world location', () => {
+      location = 'myworld.dcl.eth'
+
+      const result = buildStreamLinks(cast2BaseUrl, streamingKey, location)
+
+      expect(result.streamLink).toBe('https://cast2.decentraland.org/s/cast2-link-abc123')
+      expect(result.watcherLink).toBe('https://cast2.decentraland.org/w/myworld.dcl.eth')
+    })
+
+    it('should build correct links with fallback location', () => {
+      location = 'none'
+
+      const result = buildStreamLinks(cast2BaseUrl, streamingKey, location)
+
+      expect(result.streamLink).toBe('https://cast2.decentraland.org/s/cast2-link-abc123')
+      expect(result.watcherLink).toBe('https://cast2.decentraland.org/w/none')
+    })
+
+    it('should handle different base URLs', () => {
+      cast2BaseUrl = 'http://localhost:3000'
+
+      const result = buildStreamLinks(cast2BaseUrl, streamingKey, location)
+
+      expect(result.streamLink).toBe('http://localhost:3000/s/cast2-link-abc123')
+      expect(result.watcherLink).toBe('http://localhost:3000/w/10,20')
+    })
+
+    it('should handle streaming keys with special characters', () => {
+      streamingKey = 'cast2-link-abc123-def456'
+
+      const result = buildStreamLinks(cast2BaseUrl, streamingKey, location)
+
+      expect(result.streamLink).toBe('https://cast2.decentraland.org/s/cast2-link-abc123-def456')
+      expect(result.watcherLink).toBe('https://cast2.decentraland.org/w/10,20')
+    })
+  })
+})


### PR DESCRIPTION
# Unified Streaming Key for OBS and Cast2

## Motivation

Previously, generating a streaming key for OBS (via `/scene-stream-access`) and generating a link for Cast2 browser-based streaming (via `/cast/generate-stream-link`) were independent operations. This created two issues:

1. **Key Conflicts**: Generating a key in one system could invalidate or not work with the other system
2. **Incompatibility**: OBS keys lacked `room_id` needed for Cast2, and Cast2 keys lacked `ingress_id` needed for OBS
3. **No Reuse**: Neither system would reuse an existing active key, creating unnecessary entries

## Changes

### Core Logic

1. **Unified Key Generation**: Both endpoints now create a `SceneStreamAccess` entry with **both** `ingress_id` (for OBS RTMP) and `room_id` (for Cast2 WebRTC)
2. **Intelligent Reuse**: Both endpoints check for an existing active key for the same place/room and reuse it if:
   - It exists and is active
   - It hasn't expired (4-day TTL)
   - It matches the current room_id (for Cast2)
3. **Automatic Cleanup**: All keys now have a 4-day expiration enforced by existing TTL jobs

## Usage Scenarios

### Scenario 1: Generate Cast2 Link First
1. User generates Cast2 link → Creates key with `ingress_id` + `room_id`
2. User generates OBS link → Reuses same key (has `ingress_id`)
3. Both Cast2 and OBS work with the same key ✅

### Scenario 2: Generate OBS Link First
1. User generates OBS link → Creates key with `ingress_id` + `room_id`
2. User generates Cast2 link → Reuses same key (has `room_id`)
3. Both OBS and Cast2 work with the same key ✅

### Scenario 3: Key Expires
1. Existing key is older than 4 days
2. Generate new link (either Cast2 or OBS) → Creates fresh key
3. Old key is automatically cleaned by TTL job

### Scenario 4: Multiple Calls
1. Generate Cast2 link → Creates key
2. Generate Cast2 link again (within 4 days) → Reuses same key
3. Generate OBS link → Reuses same key
4. All use the same streaming key ✅
