### PR TITLE
fix: ingress id unique error

### DIFF
--- a/src/adapters/scene-stream-access-manager.ts
+++ b/src/adapters/scene-stream-access-manager.ts
@@ -19,7 +19,7 @@ export async function createSceneStreamAccessManagerComponent({
     await database.query(
       SQL`UPDATE scene_stream_access 
           SET active = false 
-          WHERE place_id = ${input.place_id} AND active = true`
+          WHERE (place_id = ${input.place_id} OR ingress_id = ${input.ingress_id}) AND active = true`
     )
 
     const now = Date.now()

--- a/test/integration/scene-stream-access/add-scene-stream-access-handler.spec.ts
+++ b/test/integration/scene-stream-access/add-scene-stream-access-handler.spec.ts
@@ -670,3 +670,89 @@ test('POST /scene-stream-access - adds streaming access for a scene', ({ compone
     expect(response.status).toBe(400)
   })
 })
+
+test('POST /scene-stream-access - deactivates previous world ingress entries when reusing the same ingress', ({
+  components,
+  stubComponents
+}) => {
+  const previousPlaceId = `place-id-world-ingress-previous`
+  const newPlaceId = `place-id-world-ingress-new`
+  const worldIngressId = 'world-ingress-id'
+  let cleanup: TestCleanup
+
+  const metadataWorld = {
+    identity: owner.authChain[0].payload,
+    realm: {
+      serverName: 'name.dcl.eth',
+      hostname: 'https://worlds-content-server.decentraland.org/',
+      protocol: 'https'
+    },
+    parcel: '0,0',
+    sceneId: 'test-scene',
+    isWorld: true
+  }
+
+  beforeAll(async () => {
+    cleanup = new TestCleanup(components.database)
+  })
+
+  beforeEach(async () => {
+    jest.spyOn(handlersUtils, 'validate').mockResolvedValue(metadataWorld)
+
+    stubComponents.places.getPlaceByWorldName.resolves({
+      id: newPlaceId,
+      world_name: metadataWorld.realm.serverName,
+      owner: owner.authChain[0].payload
+    } as PlaceAttributes)
+
+    stubComponents.sceneManager.isSceneOwnerOrAdmin.resolves(true)
+    stubComponents.livekit.getWorldRoomName.resolves(metadataWorld.realm.serverName)
+    stubComponents.livekit.getOrCreateIngress.resolves({
+      name: 'mock-ingress',
+      url: 'rtmp://mock-stream-url',
+      streamKey: 'mock-stream-key',
+      ingressId: worldIngressId
+    } as IngressInfo)
+  })
+
+  afterEach(async () => {
+    await cleanup.cleanup()
+    jest.restoreAllMocks()
+  })
+
+  it('should deactivate the previously active world access before creating the new one', async () => {
+    const { localFetch, sceneStreamAccessManager } = components
+
+    const previousAccess = await sceneStreamAccessManager.addAccess({
+      place_id: previousPlaceId,
+      streaming_url: 'rtmp://existing-stream-url',
+      streaming_key: 'existing-stream-key',
+      ingress_id: worldIngressId,
+      room_id: metadataWorld.realm.serverName,
+      generated_by: owner.authChain[0].payload
+    })
+    cleanup.trackInsert('scene_stream_access', { id: previousAccess.id })
+
+    const response = await makeRequest(
+      localFetch,
+      '/scene-stream-access',
+      {
+        method: 'POST',
+        metadata: metadataWorld
+      },
+      owner
+    )
+
+    expect(response.status).toBe(200)
+
+    await expect(sceneStreamAccessManager.getAccess(previousPlaceId)).rejects.toBeInstanceOf(
+      StreamingAccessNotFoundError
+    )
+
+    const newAccess = await sceneStreamAccessManager.getAccess(newPlaceId)
+    expect(newAccess.ingress_id).toBe(worldIngressId)
+    expect(newAccess.active).toBe(true)
+
+    cleanup.trackInsert('scene_stream_access', { id: newAccess.id })
+  })
+})


### PR DESCRIPTION
Closes https://github.com/decentraland/core-team/issues/115

This pull request updates the logic for deactivating previous streaming access entries when a new access is created for the same ingress, ensuring only one active entry per ingress. It also adds a comprehensive integration test to verify this behavior.

**Database update logic:**

* Modified the SQL query in `scene-stream-access-manager.ts` to deactivate all active `scene_stream_access` entries that match either the same `place_id` or `ingress_id`, instead of only those matching `place_id`. This allows us to bypass the compound unique constraint defined [here](https://github.com/decentraland/comms-gatekeeper/blob/main/src/migrations/1744398181271_scene-stream-ttl.ts#L10-L14)

**Testing improvements:**

* Added an integration test in `add-scene-stream-access-handler.spec.ts` to verify that when a new access is created with an existing `ingress_id`, any previous active entries for that ingress are deactivated and only the new access remains active.