### PR TITLE
feat: filter out events from localpreview realm

### DIFF
--- a/src/logic/livekit-webhook/event-handlers/participant-joined-handler.ts
+++ b/src/logic/livekit-webhook/event-handlers/participant-joined-handler.ts
@@ -2,8 +2,8 @@ import { Room, WebhookEvent } from 'livekit-server-sdk'
 import { ILivekitWebhookEventHandler, WebhookEventName } from './types'
 import { AppComponents } from '../../../types'
 import { AnalyticsEvent } from '../../../types/analytics'
-import { isRoomEventValid, isVoiceChatRoom } from './utils'
 import { Events, RoomType } from '@dcl/schemas'
+import { isPreviewRealm, isRoomEventValid, isVoiceChatRoom } from './utils'
 import { UserJoinedRoomEvent } from '@dcl/schemas'
 
 export function createParticipantJoinedHandler(
@@ -18,6 +18,12 @@ export function createParticipantJoinedHandler(
 
     if (roomType === RoomType.UNKNOWN) {
       logger.warn(`Unknown room type for participant joined: ${room.name}`)
+      return
+    }
+
+    // Do not publish events for preview realms (Creator Hub, local development)
+    if (isPreviewRealm(realmName) || isPreviewRealm(worldName)) {
+      logger.debug(`Skipping UserJoinedRoomEvent for preview realm: ${realmName ?? worldName}`)
       return
     }
 

--- a/src/logic/livekit-webhook/event-handlers/participant-left-handler.ts
+++ b/src/logic/livekit-webhook/event-handlers/participant-left-handler.ts
@@ -3,7 +3,7 @@ import { WebhookEvent } from 'livekit-server-sdk'
 import { ILivekitWebhookEventHandler, WebhookEventName } from './types'
 import { AppComponents } from '../../../types'
 import { AnalyticsEvent } from '../../../types/analytics'
-import { isRoomEventValid, isVoiceChatRoom } from './utils'
+import { isPreviewRealm, isRoomEventValid, isVoiceChatRoom } from './utils'
 
 export function createParticipantLeftHandler(
   components: Pick<AppComponents, 'voice' | 'analytics' | 'logs' | 'livekit' | 'publisher'>
@@ -26,6 +26,13 @@ export function createParticipantLeftHandler(
         logger.warn(`Unknown room type for participant left: ${room.name}`)
         return
       }
+
+      // Do not publish events for preview realms (Creator Hub, local development)
+      if (isPreviewRealm(realmName) || isPreviewRealm(worldName)) {
+        logger.debug(`Skipping UserLeftRoomEvent for preview realm: ${realmName ?? worldName}`)
+        return
+      }
+
       const userAddress = participant.identity.toLowerCase().slice(0, 42)
 
       const event: UserLeftRoomEvent = {

--- a/src/logic/livekit-webhook/event-handlers/utils.ts
+++ b/src/logic/livekit-webhook/event-handlers/utils.ts
@@ -1,7 +1,23 @@
 import { WebhookEvent } from 'livekit-server-sdk'
 
+// Realm names that indicate a preview/local development environment
+// These should not generate events for credits or other production features
+const PREVIEW_REALM_NAMES = ['preview', 'localpreview']
+
 export function isVoiceChatRoom(webhookEvent: WebhookEvent): boolean {
   return webhookEvent.room?.name?.startsWith('voice-chat') ?? false
+}
+
+/**
+ * Checks if the realm name indicates a preview/local development environment
+ * @param realmName - The realm name to check
+ * @returns true if the realm is a preview realm
+ */
+export function isPreviewRealm(realmName: string | undefined): boolean {
+  if (!realmName) {
+    return false
+  }
+  return PREVIEW_REALM_NAMES.includes(realmName.toLowerCase())
 }
 
 export function isRoomEventValid(webhookEvent: WebhookEvent): webhookEvent is WebhookEvent & {

--- a/test/unit/livekit-webhook-event-handlers/participant-joined-handler.spec.ts
+++ b/test/unit/livekit-webhook-event-handlers/participant-joined-handler.spec.ts
@@ -463,6 +463,63 @@ describe('Participant Joined Handler', () => {
       })
     })
 
+    describe('and room is a preview scene room', () => {
+      let sceneId: string
+
+      beforeEach(() => {
+        sceneId = 'scene-123'
+        webhookEvent.room!.name = 'preview-scene-room'
+        getRoomMetadataFromRoomNameMock.mockReturnValue({
+          sceneId,
+          worldName: undefined,
+          realmName: 'LocalPreview',
+          roomType: RoomType.SCENE
+        })
+      })
+
+      it('should not publish UserJoinedRoomEvent for LocalPreview realm', async () => {
+        await handler.handle(webhookEvent)
+
+        expect(publishMessagesMock).not.toHaveBeenCalled()
+      })
+
+      it('should still fire analytics event', async () => {
+        await handler.handle(webhookEvent)
+
+        expect(fireEventMock).toHaveBeenCalledWith(AnalyticsEvent.PARTICIPANT_JOINED_ROOM, {
+          room: webhookEvent.room!.name,
+          address: userAddress
+        })
+      })
+
+      it('should still call sceneBans.updateRoomMetadataWithBans', async () => {
+        await handler.handle(webhookEvent)
+
+        expect(updateRoomMetadataWithBansMock).toHaveBeenCalledWith(webhookEvent.room)
+      })
+    })
+
+    describe('and room is a preview realm with lowercase name', () => {
+      let sceneId: string
+
+      beforeEach(() => {
+        sceneId = 'scene-456'
+        webhookEvent.room!.name = 'preview-scene-room'
+        getRoomMetadataFromRoomNameMock.mockReturnValue({
+          sceneId,
+          worldName: undefined,
+          realmName: 'preview',
+          roomType: RoomType.SCENE
+        })
+      })
+
+      it('should not publish UserJoinedRoomEvent for preview realm', async () => {
+        await handler.handle(webhookEvent)
+
+        expect(publishMessagesMock).not.toHaveBeenCalled()
+      })
+    })
+
     describe('and message publishing fails', () => {
       let publishError: Error
       let sceneId: string

--- a/test/unit/livekit-webhook-event-handlers/participant-left-handler.spec.ts
+++ b/test/unit/livekit-webhook-event-handlers/participant-left-handler.spec.ts
@@ -284,6 +284,50 @@ describe('Participant Left Handler', () => {
         })
       })
 
+      describe('and room is a preview scene room (LocalPreview)', () => {
+        beforeEach(() => {
+          getRoomMetadataFromRoomNameMock.mockReset()
+          webhookEvent.room!.name = 'preview-scene-room'
+          getRoomMetadataFromRoomNameMock.mockReturnValue({
+            sceneId: 'scene-123',
+            worldName: undefined,
+            realmName: 'LocalPreview',
+            roomType: RoomType.SCENE
+          })
+        })
+
+        it('should not publish the user left room event for preview realm', async () => {
+          await handler.handle(webhookEvent)
+
+          expect(publishMessagesMock).not.toHaveBeenCalled()
+        })
+
+        it('should not fire analytics event for preview realm', async () => {
+          await handler.handle(webhookEvent)
+
+          expect(fireEventMock).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('and room is a preview scene room (preview lowercase)', () => {
+        beforeEach(() => {
+          getRoomMetadataFromRoomNameMock.mockReset()
+          webhookEvent.room!.name = 'preview-scene-room'
+          getRoomMetadataFromRoomNameMock.mockReturnValue({
+            sceneId: 'scene-456',
+            worldName: undefined,
+            realmName: 'preview',
+            roomType: RoomType.SCENE
+          })
+        })
+
+        it('should not publish the user left room event for preview realm', async () => {
+          await handler.handle(webhookEvent)
+
+          expect(publishMessagesMock).not.toHaveBeenCalled()
+        })
+      })
+
       describe('and publishing the user left room event fails', () => {
         beforeEach(() => {
           publishMessagesMock.mockRejectedValue(new Error('Failed to publish user left room event'))

--- a/test/unit/livekit-webhook-event-handlers/utils.spec.ts
+++ b/test/unit/livekit-webhook-event-handlers/utils.spec.ts
@@ -1,0 +1,173 @@
+import {
+  isPreviewRealm,
+  isRoomEventValid,
+  isVoiceChatRoom
+} from '../../../src/logic/livekit-webhook/event-handlers/utils'
+import { WebhookEvent } from 'livekit-server-sdk'
+
+describe('webhook event handler utils', () => {
+  describe('when calling isVoiceChatRoom', () => {
+    describe('and the room name starts with voice-chat', () => {
+      let webhookEvent: WebhookEvent
+
+      beforeEach(() => {
+        webhookEvent = {
+          room: {
+            name: 'voice-chat-private-123'
+          }
+        } as WebhookEvent
+      })
+
+      it('should return true', () => {
+        expect(isVoiceChatRoom(webhookEvent)).toBe(true)
+      })
+    })
+
+    describe('and the room name does not start with voice-chat', () => {
+      let webhookEvent: WebhookEvent
+
+      beforeEach(() => {
+        webhookEvent = {
+          room: {
+            name: 'scene-room-name'
+          }
+        } as WebhookEvent
+      })
+
+      it('should return false', () => {
+        expect(isVoiceChatRoom(webhookEvent)).toBe(false)
+      })
+    })
+
+    describe('and the room is undefined', () => {
+      let webhookEvent: WebhookEvent
+
+      beforeEach(() => {
+        webhookEvent = {} as WebhookEvent
+      })
+
+      it('should return false', () => {
+        expect(isVoiceChatRoom(webhookEvent)).toBe(false)
+      })
+    })
+  })
+
+  describe('when calling isRoomEventValid', () => {
+    describe('and room and participant are present with valid data', () => {
+      let webhookEvent: WebhookEvent
+
+      beforeEach(() => {
+        webhookEvent = {
+          room: { name: 'test-room' },
+          participant: { identity: '0x123' }
+        } as unknown as WebhookEvent
+      })
+
+      it('should return true', () => {
+        expect(isRoomEventValid(webhookEvent)).toBe(true)
+      })
+    })
+
+    describe('and room is missing', () => {
+      let webhookEvent: WebhookEvent
+
+      beforeEach(() => {
+        webhookEvent = {
+          participant: { identity: '0x123' }
+        } as unknown as WebhookEvent
+      })
+
+      it('should return false', () => {
+        expect(isRoomEventValid(webhookEvent)).toBe(false)
+      })
+    })
+
+    describe('and participant is missing', () => {
+      let webhookEvent: WebhookEvent
+
+      beforeEach(() => {
+        webhookEvent = {
+          room: { name: 'test-room' }
+        } as unknown as WebhookEvent
+      })
+
+      it('should return false', () => {
+        expect(isRoomEventValid(webhookEvent)).toBe(false)
+      })
+    })
+  })
+
+  describe('when calling isPreviewRealm', () => {
+    describe('and the realm name is preview (lowercase)', () => {
+      it('should return true', () => {
+        expect(isPreviewRealm('preview')).toBe(true)
+      })
+    })
+
+    describe('and the realm name is Preview (mixed case)', () => {
+      it('should return true', () => {
+        expect(isPreviewRealm('Preview')).toBe(true)
+      })
+    })
+
+    describe('and the realm name is PREVIEW (uppercase)', () => {
+      it('should return true', () => {
+        expect(isPreviewRealm('PREVIEW')).toBe(true)
+      })
+    })
+
+    describe('and the realm name is LocalPreview (mixed case)', () => {
+      it('should return true', () => {
+        expect(isPreviewRealm('LocalPreview')).toBe(true)
+      })
+    })
+
+    describe('and the realm name is localpreview (lowercase)', () => {
+      it('should return true', () => {
+        expect(isPreviewRealm('localpreview')).toBe(true)
+      })
+    })
+
+    describe('and the realm name is LOCALPREVIEW (uppercase)', () => {
+      it('should return true', () => {
+        expect(isPreviewRealm('LOCALPREVIEW')).toBe(true)
+      })
+    })
+
+    describe('and the realm name is a production realm', () => {
+      it('should return false for hela', () => {
+        expect(isPreviewRealm('hela')).toBe(false)
+      })
+
+      it('should return false for dg', () => {
+        expect(isPreviewRealm('dg')).toBe(false)
+      })
+
+      it('should return false for a world name', () => {
+        expect(isPreviewRealm('myworld.eth')).toBe(false)
+      })
+    })
+
+    describe('and the realm name is undefined', () => {
+      it('should return false', () => {
+        expect(isPreviewRealm(undefined)).toBe(false)
+      })
+    })
+
+    describe('and the realm name is empty string', () => {
+      it('should return false', () => {
+        expect(isPreviewRealm('')).toBe(false)
+      })
+    })
+
+    describe('and the realm name contains preview but is not exactly preview', () => {
+      it('should return false for preview-something', () => {
+        expect(isPreviewRealm('preview-something')).toBe(false)
+      })
+
+      it('should return false for my-preview', () => {
+        expect(isPreviewRealm('my-preview')).toBe(false)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Problem

Users previewing their scenes from Creator Hub are progressing towards credits goals. This should not happen - progress should be limited only to real in-world connections.

### Solution

Added filtering logic to skip publishing `USER_JOINED_ROOM` and `USER_LEFT_ROOM` events when the realm is a preview realm (`preview` or `LocalPreview`).
