### PR TITLE
feat: Add world bans endpoint

### DIFF
--- a/src/controllers/handlers/world-ban-check-handler.ts
+++ b/src/controllers/handlers/world-ban-check-handler.ts
@@ -1,0 +1,49 @@
+import { IHttpServerComponent } from '@well-known-components/interfaces'
+import { HandlerContextWithPath } from '../../types'
+
+/**
+ * Handler for checking if a user is banned from a world.
+ *
+ * This endpoint is authenticated via bearer token (COMMS_GATEKEEPER_AUTH_TOKEN)
+ * and is intended for service-to-service communication (e.g. worlds-content-server).
+ *
+ * @param context - The handler context with sceneBans and logs components.
+ * @returns A response with { isBanned: boolean }.
+ */
+export async function worldBanCheckHandler(
+  context: HandlerContextWithPath<'sceneBans' | 'logs', '/worlds/:worldName/users/:address/ban-status'>
+): Promise<IHttpServerComponent.IResponse> {
+  const {
+    components: { sceneBans, logs }
+  } = context
+
+  const logger = logs.getLogger('world-ban-check-handler')
+
+  const { worldName, address } = context.params
+
+  try {
+    const isBanned = await sceneBans.isUserBanned(address, {
+      realmName: worldName,
+      isWorld: true,
+      parcel: ''
+    })
+
+    logger.debug(`Ban check for ${address} in world ${worldName}: ${isBanned ? 'banned' : 'not banned'}`)
+
+    return {
+      status: 200,
+      body: {
+        isBanned
+      }
+    }
+  } catch (error) {
+    logger.warn(`Error checking ban status for ${address} in world ${worldName}: ${error}`)
+
+    return {
+      status: 200,
+      body: {
+        isBanned: false
+      }
+    }
+  }
+}

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -40,6 +40,7 @@ import {
 } from './handlers/community-voice-chat'
 import { getAllActiveCommunityVoiceChatsHandler } from './handlers/get-all-active-community-voice-chats-handler'
 import { commsServerSceneHandler } from './handlers/comms-server-scene-handler'
+import { worldBanCheckHandler } from './handlers/world-ban-check-handler'
 import { getSceneParticipantsHandler } from './handlers/scene-participants-handler'
 import { streamerTokenHandler, watcherTokenHandler, generateStreamLinkHandler } from './handlers/cast'
 import { getStreamInfoHandler } from './handlers/cast/get-stream-info-handler'
@@ -107,6 +108,9 @@ export async function setupRouter({ components }: GlobalContext): Promise<Router
   // Scene ban routes
   router.get('/scene-bans', auth, listSceneBansHandler)
   router.get('/scene-bans/addresses', auth, listSceneBansAddressesHandler)
+
+  // World ban check endpoint (service-to-service, used by worlds-content-server)
+  router.get('/worlds/:worldName/users/:address/ban-status', tokenAuthMiddleware, worldBanCheckHandler)
   router.post(
     '/scene-bans',
     auth,

--- a/test/integration/world-ban-check-handler.spec.ts
+++ b/test/integration/world-ban-check-handler.spec.ts
@@ -1,0 +1,137 @@
+import { test } from '../components'
+import { makeRequest } from '../utils'
+import { TestCleanup } from '../db-cleanup'
+import { createMockedWorldPlace } from '../mocks/places-mock'
+import { AddSceneBanInput } from '../../src/types'
+
+test('GET /worlds/:worldName/users/:address/ban-status', ({ components, stubComponents }) => {
+  const address = '0xd9b96b5dc720fc52bede1ec3b40a930e15f70ddd'
+  const worldName = 'my-world.eth'
+  const endpoint = `/worlds/${worldName}/users/${address}/ban-status`
+
+  let cleanup: TestCleanup
+
+  beforeAll(async () => {
+    cleanup = new TestCleanup(components.database)
+  })
+
+  afterEach(async () => {
+    await cleanup.cleanup()
+  })
+
+  describe('when the authorization token is invalid', () => {
+    let token: string
+
+    beforeEach(() => {
+      token = 'an-invalid-token'
+    })
+
+    it('should respond with a 401 and a message saying that the token is invalid', async () => {
+      const response = await makeRequest(
+        components.localFetch,
+        endpoint,
+        {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${token}`
+          }
+        }
+      )
+
+      expect(response.status).toBe(401)
+      expect(response.json()).resolves.toEqual({ error: 'Invalid authorization header' })
+    })
+  })
+
+  describe('when the authorization token is valid', () => {
+    let token: string
+    let worldPlaceId: string
+
+    beforeEach(() => {
+      token = 'aToken'
+      worldPlaceId = worldName
+
+      stubComponents.places.getWorldByName.resolves(
+        createMockedWorldPlace({
+          id: worldPlaceId,
+          world_name: worldName,
+          world: true
+        })
+      )
+    })
+
+    describe('and the user is banned from the world', () => {
+      let ban: AddSceneBanInput
+
+      beforeEach(async () => {
+        ban = {
+          placeId: worldPlaceId,
+          bannedAddress: address.toLowerCase(),
+          bannedBy: '0x0000000000000000000000000000000000000001'
+        }
+
+        await components.sceneBanManager.addBan(ban)
+        cleanup.trackInsert('scene_bans', { place_id: ban.placeId, banned_address: ban.bannedAddress })
+      })
+
+      it('should respond with a 200 and isBanned as true', async () => {
+        const response = await makeRequest(
+          components.localFetch,
+          endpoint,
+          {
+            method: 'GET',
+            headers: {
+              Authorization: `Bearer ${token}`
+            }
+          }
+        )
+
+        expect(response.status).toBe(200)
+        const body = await response.json()
+        expect(body).toEqual({ isBanned: true })
+      })
+    })
+
+    describe('and the user is not banned from the world', () => {
+      it('should respond with a 200 and isBanned as false', async () => {
+        const response = await makeRequest(
+          components.localFetch,
+          endpoint,
+          {
+            method: 'GET',
+            headers: {
+              Authorization: `Bearer ${token}`
+            }
+          }
+        )
+
+        expect(response.status).toBe(200)
+        const body = await response.json()
+        expect(body).toEqual({ isBanned: false })
+      })
+    })
+
+    describe('and the places component throws an error', () => {
+      beforeEach(() => {
+        stubComponents.places.getWorldByName.rejects(new Error('Database error'))
+      })
+
+      it('should respond with a 200 and isBanned as false (fail open)', async () => {
+        const response = await makeRequest(
+          components.localFetch,
+          endpoint,
+          {
+            method: 'GET',
+            headers: {
+              Authorization: `Bearer ${token}`
+            }
+          }
+        )
+
+        expect(response.status).toBe(200)
+        const body = await response.json()
+        expect(body).toEqual({ isBanned: false })
+      })
+    })
+  })
+})


### PR DESCRIPTION
The worlds-content-server needs to verify whether a user is banned from a world before granting a comms connection string. The ban data and business logic already live in the comms-gatekeeper (via `sceneBans.isUserBanned`), so rather than duplicating that logic, the comms-gatekeeper exposes a new service-to-service endpoint that the worlds-content-server can query.

## How

A new `GET /worlds/:worldName/users/:address/ban-status` endpoint is added, protected by the existing `COMMS_GATEKEEPER_AUTH_TOKEN` bearer token middleware (the same one used by private messages, voice chat, and community voice chat routes).

The handler extracts the `worldName` and `address` from the URL path parameters and delegates to the existing `sceneBans.isUserBanned()` logic with `isWorld: true`. This reuses the full scene-ban resolution flow (place lookup via `places.getWorldByName`, then `sceneBanManager.isBanned`) without any duplication.

The endpoint **fails open**: if `isUserBanned` throws (e.g. database or places service error), it returns `{ isBanned: false }` with a warning log, so that transient failures in the comms-gatekeeper do not block world connections on the calling side.

## Cross-repo dependency

The worlds-content-server companion PR adds a world-ban-checker adapter that calls this endpoint. Both services must share the same `COMMS_GATEKEEPER_AUTH_TOKEN` value.

Closes https://github.com/decentraland/core-team/issues/178