### PR TITLE
fix: Cast & streaming access wrongly checking world scene access

### DIFF
--- a/src/controllers/handlers/scene-stream-access-handlers/add-scene-stream-access-handler.ts
+++ b/src/controllers/handlers/scene-stream-access-handlers/add-scene-stream-access-handler.ts
@@ -20,7 +20,7 @@ export async function addSceneStreamAccessHandler(
     verification
   } = ctx
   const logger = logs.getLogger('add-scene-stream-access-handler')
-  const { getWorldScenePlace, getPlaceByParcel } = places
+  const { getWorldScenePlace, getWorldByName, getPlaceByParcel } = places
   const { isSceneOwnerOrAdmin } = sceneManager
   if (!verification?.auth) {
     logger.debug('Authentication required')
@@ -40,15 +40,19 @@ export async function addSceneStreamAccessHandler(
     throw new InvalidRequestError('Access denied, invalid signed-fetch request, no sceneId')
   }
 
+  // For worlds: use the world scene place for streaming key operations (scene-specific),
+  // but the world place for permission checks (world-wide admin/owner).
   let place: PlaceAttributes
+  let permissionPlace: PlaceAttributes
   if (isWorld) {
-    // For worlds: query /places with position and world name
     place = await getWorldScenePlace(serverName, parcel)
+    permissionPlace = await getWorldByName(serverName)
   } else {
     place = await getPlaceByParcel(parcel)
+    permissionPlace = place
   }
 
-  const isOwnerOrAdmin = await isSceneOwnerOrAdmin(place, authenticatedAddress)
+  const isOwnerOrAdmin = await isSceneOwnerOrAdmin(permissionPlace, authenticatedAddress)
   if (!isOwnerOrAdmin) {
     logger.info(`Wallet ${authenticatedAddress} is not authorized to access this scene. Place ${place.id}`)
     throw new UnauthorizedError('Access denied, you are not authorized to access this scene')

--- a/src/controllers/handlers/scene-stream-access-handlers/list-scene-stream-access-handler.ts
+++ b/src/controllers/handlers/scene-stream-access-handlers/list-scene-stream-access-handler.ts
@@ -18,7 +18,7 @@ export async function listSceneStreamAccessHandler(
     verification
   } = ctx
   const logger = logs.getLogger('get-scene-stream-access-handler')
-  const { getWorldScenePlace, getPlaceByParcel } = places
+  const { getWorldScenePlace, getWorldByName, getPlaceByParcel } = places
   const { isSceneOwnerOrAdmin } = sceneManager
   if (!verification?.auth) {
     logger.debug('Authentication required')
@@ -38,15 +38,19 @@ export async function listSceneStreamAccessHandler(
     throw new InvalidRequestError('Access denied, invalid signed-fetch request, no sceneId')
   }
 
+  // For worlds: use the world scene place for streaming key operations (scene-specific),
+  // but the world place for permission checks (world-wide admin/owner).
   let place: PlaceAttributes
+  let permissionPlace: PlaceAttributes
   if (isWorld) {
-    // For worlds: query /places with position and world name
     place = await getWorldScenePlace(serverName, parcel)
+    permissionPlace = await getWorldByName(serverName)
   } else {
     place = await getPlaceByParcel(parcel)
+    permissionPlace = place
   }
 
-  const isOwnerOrAdmin = await isSceneOwnerOrAdmin(place, authenticatedAddress)
+  const isOwnerOrAdmin = await isSceneOwnerOrAdmin(permissionPlace, authenticatedAddress)
   if (!isOwnerOrAdmin) {
     logger.info(`Wallet ${authenticatedAddress} is not authorized to access this scene. Place ${place.id}`)
     throw new UnauthorizedError('Access denied, you are not authorized to access this scene')

--- a/src/controllers/handlers/scene-stream-access-handlers/remove-scene-stream-access-handler.ts
+++ b/src/controllers/handlers/scene-stream-access-handlers/remove-scene-stream-access-handler.ts
@@ -25,7 +25,7 @@ export async function removeSceneStreamAccessHandler(
     verification
   } = ctx
   const logger = logs.getLogger('revoke-scene-stream-access-handler')
-  const { getWorldScenePlace, getPlaceByParcel } = places
+  const { getWorldScenePlace, getWorldByName, getPlaceByParcel } = places
   const { isSceneOwnerOrAdmin } = sceneManager
   if (!verification?.auth) {
     logger.debug('Authentication required')
@@ -45,15 +45,19 @@ export async function removeSceneStreamAccessHandler(
     throw new InvalidRequestError('Access denied, invalid signed-fetch request, no sceneId')
   }
 
+  // For worlds: use the world scene place for streaming key operations (scene-specific),
+  // but the world place for permission checks (world-wide admin/owner).
   let place: PlaceAttributes
+  let permissionPlace: PlaceAttributes
   if (isWorld) {
-    // For worlds: query /places with position and world name
     place = await getWorldScenePlace(serverName, parcel)
+    permissionPlace = await getWorldByName(serverName)
   } else {
     place = await getPlaceByParcel(parcel)
+    permissionPlace = place
   }
 
-  const isOwnerOrAdmin = await isSceneOwnerOrAdmin(place, authenticatedAddress)
+  const isOwnerOrAdmin = await isSceneOwnerOrAdmin(permissionPlace, authenticatedAddress)
   if (!isOwnerOrAdmin) {
     logger.info(`Wallet ${authenticatedAddress} is not authorized to access this scene. Place ${place.id}`)
     throw new UnauthorizedError('Access denied, you are not authorized to access this scene')

--- a/src/controllers/handlers/scene-stream-access-handlers/reset-scene-stream-access-handler.ts
+++ b/src/controllers/handlers/scene-stream-access-handlers/reset-scene-stream-access-handler.ts
@@ -27,7 +27,7 @@ export async function resetSceneStreamAccessHandler(
     verification
   } = ctx
   const logger = logs.getLogger('reset-scene-stream-access-handler')
-  const { getWorldScenePlace, getPlaceByParcel } = places
+  const { getWorldScenePlace, getWorldByName, getPlaceByParcel } = places
   const { isSceneOwnerOrAdmin } = sceneManager
 
   if (!verification?.auth) {
@@ -49,15 +49,19 @@ export async function resetSceneStreamAccessHandler(
   }
 
   try {
+    // For worlds: use the world scene place for streaming key operations (scene-specific),
+    // but the world place for permission checks (world-wide admin/owner).
     let place: PlaceAttributes
+    let permissionPlace: PlaceAttributes
     if (isWorld) {
-      // For worlds: query /places with position and world name
       place = await getWorldScenePlace(serverName, parcel)
+      permissionPlace = await getWorldByName(serverName)
     } else {
       place = await getPlaceByParcel(parcel)
+      permissionPlace = place
     }
 
-    const isOwnerOrAdmin = await isSceneOwnerOrAdmin(place, authenticatedAddress)
+    const isOwnerOrAdmin = await isSceneOwnerOrAdmin(permissionPlace, authenticatedAddress)
     if (!isOwnerOrAdmin) {
       logger.info(`Wallet ${authenticatedAddress} is not authorized to access this scene. Place ${place.id}`)
       throw new UnauthorizedError('Access denied, you are not authorized to access this scene')

--- a/src/logic/cast/cast.ts
+++ b/src/logic/cast/cast.ts
@@ -45,15 +45,20 @@ export function createCastComponent(
     const { walletAddress, worldName, parcel, sceneId, realmName } = params
 
     // Get place information
+    // For worlds: use the world scene place for streaming key generation (scene-specific),
+    // but the world place for permission checks (world-wide admin/owner).
     let place: PlaceAttributes
+    let permissionPlace: PlaceAttributes
     if (worldName) {
       place = await places.getWorldScenePlace(worldName, parcel)
+      permissionPlace = await places.getWorldByName(worldName)
     } else {
       place = await places.getPlaceByParcel(parcel)
+      permissionPlace = place
     }
 
-    // Verify the user is a scene admin
-    const isAdmin = await sceneManager.isSceneOwnerOrAdmin(place, walletAddress)
+    // Verify the user is a scene admin (using world place for worlds)
+    const isAdmin = await sceneManager.isSceneOwnerOrAdmin(permissionPlace, walletAddress)
 
     if (!isAdmin) {
       logger.warn(

--- a/test/integration/scene-stream-access/add-scene-stream-access-handler.spec.ts
+++ b/test/integration/scene-stream-access/add-scene-stream-access-handler.spec.ts
@@ -90,6 +90,12 @@ test('GET /scene-stream-access - gets streaming access for scenes', ({ component
       owner: owner.authChain[0].payload
     } as PlaceAttributes)
 
+    stubComponents.places.getWorldByName.resolves({
+      id: 'world-place-id',
+      world_name: 'name.dcl.eth',
+      owner: owner.authChain[0].payload
+    } as PlaceAttributes)
+
     stubComponents.lands.getLandPermissions.resolves({
       owner: true,
       operator: false,
@@ -442,6 +448,12 @@ test('POST /scene-stream-access - adds streaming access for a scene', ({ compone
 
     stubComponents.places.getWorldScenePlace.resolves({
       id: placeWorldId,
+      world_name: 'name.dcl.eth',
+      owner: owner.authChain[0].payload
+    } as PlaceAttributes)
+
+    stubComponents.places.getWorldByName.resolves({
+      id: 'world-place-id',
       world_name: 'name.dcl.eth',
       owner: owner.authChain[0].payload
     } as PlaceAttributes)

--- a/test/integration/scene-stream-access/get-scene-stream-access-handler.spec.ts
+++ b/test/integration/scene-stream-access/get-scene-stream-access-handler.spec.ts
@@ -98,6 +98,11 @@ test('GET /scene-stream-access - gets streaming access for scenes', ({ component
       world_name: 'name.dcl.eth',
       owner: owner.authChain[0].payload
     } as PlaceAttributes)
+    stubComponents.places.getWorldByName.resolves({
+      id: 'world-place-id',
+      world_name: 'name.dcl.eth',
+      owner: owner.authChain[0].payload
+    } as PlaceAttributes)
     stubComponents.lands.getLandPermissions.resolves({
       owner: true,
       operator: false,

--- a/test/integration/scene-stream-access/list-scene-stream-access-handler.spec.ts
+++ b/test/integration/scene-stream-access/list-scene-stream-access-handler.spec.ts
@@ -80,6 +80,11 @@ test('GET /scene-stream-access - lists streaming access for scenes', ({ componen
       world_name: 'name.dcl.eth',
       owner: owner.authChain[0].payload
     } as PlaceAttributes)
+    stubComponents.places.getWorldByName.resolves({
+      id: 'world-place-id',
+      world_name: 'name.dcl.eth',
+      owner: owner.authChain[0].payload
+    } as PlaceAttributes)
     stubComponents.lands.getLandPermissions.resolves({
       owner: true,
       operator: false,

--- a/test/integration/scene-stream-access/remove-scene-stream-access-handler.spec.ts
+++ b/test/integration/scene-stream-access/remove-scene-stream-access-handler.spec.ts
@@ -88,6 +88,12 @@ test('DELETE /scene-stream-access - removes streaming access for scenes', ({ com
       owner: owner.authChain[0].payload
     } as PlaceAttributes)
 
+    stubComponents.places.getWorldByName.resolves({
+      id: 'world-place-id',
+      world_name: 'name.dcl.eth',
+      owner: owner.authChain[0].payload
+    } as PlaceAttributes)
+
     stubComponents.sceneStreamAccessManager.getAccess.resolves(mockSceneStreamAccess)
     stubComponents.sceneStreamAccessManager.removeAccess.resolves()
     stubComponents.sceneManager.getUserScenePermissions.resolves({

--- a/test/integration/scene-stream-access/reset-scene-stream-access-handler.spec.ts
+++ b/test/integration/scene-stream-access/reset-scene-stream-access-handler.spec.ts
@@ -99,6 +99,12 @@ test('PUT /scene-stream-access - resets streaming access for scenes', ({ compone
       owner: owner.authChain[0].payload
     } as PlaceAttributes)
 
+    stubComponents.places.getWorldByName.resolves({
+      id: 'world-place-id',
+      world_name: 'name.dcl.eth',
+      owner: owner.authChain[0].payload
+    } as PlaceAttributes)
+
     stubComponents.lands.getLandPermissions.resolves({
       owner: true,
       operator: false,

--- a/test/unit/cast/generate-stream-link.spec.ts
+++ b/test/unit/cast/generate-stream-link.spec.ts
@@ -19,6 +19,7 @@ describe('when generating a stream link', () => {
   let mockConfig: ReturnType<typeof createConfigMockedComponent>
   let mockPlace: PlaceAttributes
   let mockWorldPlace: PlaceAttributes
+  let mockWorldScenePlace: PlaceAttributes
 
   beforeEach(() => {
     mockPlace = createMockedPlace({
@@ -31,6 +32,13 @@ describe('when generating a stream link', () => {
     mockWorldPlace = createMockedWorldPlace({
       id: 'world-place-123',
       title: 'Test World Place',
+      owner: '0xowner123',
+      world_name: 'test-world.dcl.eth'
+    })
+
+    mockWorldScenePlace = createMockedWorldPlace({
+      id: 'world-scene-place-456',
+      title: 'Test World Scene Place',
       owner: '0xowner123',
       world_name: 'test-world.dcl.eth'
     })
@@ -69,7 +77,7 @@ describe('when generating a stream link', () => {
     })
 
     mockPlaces = createPlacesMockedComponent({
-      getWorldScenePlace: jest.fn().mockResolvedValue(mockWorldPlace),
+      getWorldScenePlace: jest.fn().mockResolvedValue(mockWorldScenePlace),
       getWorldByName: jest.fn().mockResolvedValue(mockWorldPlace),
       getPlaceByParcel: jest.fn().mockResolvedValue(mockPlace)
     })
@@ -137,7 +145,8 @@ describe('when generating a stream link', () => {
   describe('and the request is for a world', () => {
     beforeEach(() => {
       mockSceneManager.isSceneOwnerOrAdmin.mockResolvedValue(true)
-      mockPlaces.getWorldScenePlace.mockResolvedValue(mockWorldPlace)
+      mockPlaces.getWorldScenePlace.mockResolvedValue(mockWorldScenePlace)
+      mockPlaces.getWorldByName.mockResolvedValue(mockWorldPlace)
     })
 
     it('should get the world scene room with the scene id', async () => {
@@ -164,7 +173,20 @@ describe('when generating a stream link', () => {
       expect(mockPlaces.getWorldScenePlace).toHaveBeenCalledWith('test-world.dcl.eth', '0,0')
     })
 
-    it('should return the world place id', async () => {
+    it('should check admin permissions using the world place, not the world scene place', async () => {
+      await castComponent.generateStreamLink({
+        walletAddress: '0xowner123',
+        worldName: 'test-world.dcl.eth',
+        parcel: '0,0',
+        sceneId: 'bafkreiscene123',
+        realmName: 'test-world.dcl.eth'
+      })
+
+      expect(mockPlaces.getWorldByName).toHaveBeenCalledWith('test-world.dcl.eth')
+      expect(mockSceneManager.isSceneOwnerOrAdmin).toHaveBeenCalledWith(mockWorldPlace, '0xowner123')
+    })
+
+    it('should return the world scene place id', async () => {
       const result = await castComponent.generateStreamLink({
         walletAddress: '0xowner123',
         worldName: 'test-world.dcl.eth',
@@ -173,14 +195,15 @@ describe('when generating a stream link', () => {
         realmName: 'test-world.dcl.eth'
       })
 
-      expect(result.placeId).toBe('world-place-123')
+      expect(result.placeId).toBe('world-scene-place-456')
     })
   })
 
   describe('and the user is not an admin', () => {
     beforeEach(() => {
       mockSceneManager.isSceneOwnerOrAdmin.mockResolvedValue(false)
-      mockPlaces.getWorldScenePlace.mockResolvedValue(mockWorldPlace)
+      mockPlaces.getWorldScenePlace.mockResolvedValue(mockWorldScenePlace)
+      mockPlaces.getWorldByName.mockResolvedValue(mockWorldPlace)
     })
 
     it('should throw an UnauthorizedError', async () => {
@@ -201,7 +224,7 @@ describe('when generating a stream link', () => {
       beforeEach(() => {
         const existingAccess = {
           id: 'access-123',
-          place_id: 'world-place-123',
+          place_id: 'world-scene-place-456',
           streaming_url: 'rtmp://test-url',
           ingress_id: 'test-ingress-id',
           created_at: Date.now(),
@@ -235,7 +258,7 @@ describe('when generating a stream link', () => {
       beforeEach(() => {
         const expiredAccess = {
           id: 'access-123',
-          place_id: 'world-place-123',
+          place_id: 'world-scene-place-456',
           streaming_url: 'rtmp://test-url',
           ingress_id: 'test-ingress-id',
           created_at: Date.now(),
@@ -269,7 +292,7 @@ describe('when generating a stream link', () => {
       beforeEach(() => {
         const differentRoomAccess = {
           id: 'access-123',
-          place_id: 'world-place-123',
+          place_id: 'world-scene-place-456',
           streaming_url: 'rtmp://test-url',
           ingress_id: 'test-ingress-id',
           created_at: Date.now(),
@@ -302,7 +325,8 @@ describe('when generating a stream link', () => {
   describe('and the stream link is successfully generated', () => {
     beforeEach(() => {
       mockSceneManager.isSceneOwnerOrAdmin.mockResolvedValue(true)
-      mockPlaces.getWorldScenePlace.mockResolvedValue(mockWorldPlace)
+      mockPlaces.getWorldScenePlace.mockResolvedValue(mockWorldScenePlace)
+      mockPlaces.getWorldByName.mockResolvedValue(mockWorldPlace)
     })
 
     it('should return the stream link details with place name and expiration information', async () => {
@@ -316,7 +340,7 @@ describe('when generating a stream link', () => {
 
       expect(result.streamLink).toBe('https://cast2.decentraland.org/s/test-stream-key')
       expect(result.watcherLink).toBe('https://cast2.decentraland.org/w/test-world.dcl.eth')
-      expect(result.placeName).toBe('Test World Place')
+      expect(result.placeName).toBe('Test World Scene Place')
       expect(result.expiresAt).toBeDefined()
       expect(result.expiresInDays).toBeGreaterThan(0)
     })


### PR DESCRIPTION
When a user requested a stream link for a scene inside a world, the `generateStreamLink` function used the **world scene place** (the specific scene within the world) for both:

1. Checking whether the user is an owner or admin.
2. Generating and storing the streaming key.

This meant the admin/owner check was running against the scene-level place entity, which doesn't carry the world-level ownership and admin information. A user who is an admin of the *world* — but not explicitly listed on that particular *scene* place — would be denied permission to generate a stream link.

## Why this matters

Worlds in Decentraland can contain multiple scenes, each represented by its own place entity. However, ownership and admin roles are managed at the **world level**, not per-scene. Other features like scene bans already handle this correctly by using `getWorldByName` to resolve permissions against the world place. The cast/streaming feature was inconsistent with this pattern, leading to permission failures for legitimate world admins.

## What changed

In `generateStreamLink`, when the request targets a world scene, we now fetch **two** place entities:

- **World scene place** (`getWorldScenePlace`) — used for streaming key generation, stream access storage, and all scene-specific data (place ID, title, room ID). This ensures the streaming key is scoped to the correct scene within the world.
- **World place** (`getWorldByName`) — used exclusively for the `isSceneOwnerOrAdmin` permission check. This ensures world-level admins and owners are correctly authorized.

For non-world parcels, both resolve to the same place, so the behavior is unchanged.

## How it works

```
// Before (world case):
place = getWorldScenePlace(worldName, parcel)
isSceneOwnerOrAdmin(place, walletAddress)       // scene-level check ← wrong
streamAccessManager.addAccess({ place_id: place.id })

// After (world case):
place           = getWorldScenePlace(worldName, parcel)  // for streaming key
permissionPlace = getWorldByName(worldName)              // for admin check
isSceneOwnerOrAdmin(permissionPlace, walletAddress)      // world-level check ← correct
streamAccessManager.addAccess({ place_id: place.id })    // still scene-scoped
```

This aligns the cast feature with how `scene-bans` already handles world permission checks.