### PR TITLE
fix: Parcels endpoint throwing 404 when the user has no permissions

### DIFF
--- a/src/adapters/scene-manager.ts
+++ b/src/adapters/scene-manager.ts
@@ -33,16 +33,18 @@ export async function createSceneManagerComponent(
         getWorldParcelPermissions(address, place.world_name!, 'streaming'),
         getWorldParcelPermissions(address, place.world_name!, 'deployment')
       ])
+      const streamingParcelList = streamingParcels ?? []
+      const deployParcelList = deployParcels ?? []
 
       const sceneParcels = new Set(place.positions)
 
       // World-wide permission: in allow list + no specific parcels = applies to all scenes
-      const hasWorldWideStreaming = hasWorldStreaming && streamingParcels.length === 0
-      const hasWorldWideDeploy = hasWorldDeploy && deployParcels.length === 0
+      const hasWorldWideStreaming = hasWorldStreaming && streamingParcelList.length === 0
+      const hasWorldWideDeploy = hasWorldDeploy && deployParcelList.length === 0
 
       // Parcel-specific permission: parcels overlap with this scene's positions
-      const hasParcelStreaming = streamingParcels.some((p) => sceneParcels.has(p))
-      const hasParcelDeploy = deployParcels.some((p) => sceneParcels.has(p))
+      const hasParcelStreaming = streamingParcelList.some((p) => sceneParcels.has(p))
+      const hasParcelDeploy = deployParcelList.some((p) => sceneParcels.has(p))
 
       hasExtendedPermissions = hasWorldWideStreaming || hasWorldWideDeploy || hasParcelStreaming || hasParcelDeploy
     } else if (!isAdmin && !place.world) {
@@ -69,6 +71,7 @@ export async function createSceneManagerComponent(
 
   async function isSceneOwnerOrAdmin(place: PlaceAttributes, authenticatedAddress: string): Promise<boolean> {
     const authenticatedUserScenePermissions = await getUserScenePermissions(place, authenticatedAddress)
+
     return (
       authenticatedUserScenePermissions.owner ||
       authenticatedUserScenePermissions.admin ||

--- a/src/adapters/worlds.ts
+++ b/src/adapters/worlds.ts
@@ -115,10 +115,17 @@ export async function createWorldsComponent(
     address: string,
     worldName: string,
     permissionName: string
-  ): Promise<string[]> {
+  ): Promise<string[] | undefined> {
     const url = `${worldContentUrl}/world/${worldName.toLowerCase()}/permissions/${permissionName}/address/${address.toLowerCase()}/parcels`
-    const response = await cachedFetch.cache<{ total: number; parcels: string[] }>().fetch(url)
-    return response?.parcels ?? []
+    const response = await fetch.fetch(url)
+    if (!response.ok) {
+      if (response.status === 404) {
+        return undefined
+      }
+      throw new Error(`Error getting ${url}, status: ${response.status}`)
+    }
+    const result = (await response.json()) as { total: number; parcels: string[] }
+    return result?.parcels ?? []
   }
 
   /**

--- a/src/types/worlds.type.ts
+++ b/src/types/worlds.type.ts
@@ -25,7 +25,7 @@ export type IWorldComponent = IBaseComponent & {
   hasWorldStreamingPermission(authAddress: string, worldName: string): Promise<boolean>
   hasWorldDeployPermission(authAddress: string, worldName: string): Promise<boolean>
   hasWorldAccessPermission(authAddress: string, worldName: string): Promise<boolean>
-  getWorldParcelPermissions(address: string, worldName: string, permissionName: string): Promise<string[]>
+  getWorldParcelPermissions(address: string, worldName: string, permissionName: string): Promise<string[] | undefined>
   getWorldParcelPermissionAddresses(worldName: string, permissionName: string, parcels: string[]): Promise<string[]>
 }
 

--- a/test/integration/scene-manager-component.spec.ts
+++ b/test/integration/scene-manager-component.spec.ts
@@ -216,6 +216,17 @@ test('SceneManagerComponent', ({ stubComponents }) => {
         hasLandLease: false
       })
     })
+
+    it('should return all false when getWorldParcelPermissions returns undefined (no permissions set, e.g. 404)', async () => {
+      stubComponents.worlds.getWorldParcelPermissions.resolves(undefined)
+      const result = await sceneManager.getUserScenePermissions(worldPlace, testAddress)
+      expect(result).toEqual({
+        owner: false,
+        admin: false,
+        hasExtendedPermissions: false,
+        hasLandLease: false
+      })
+    })
   })
 
   describe('isSceneOwnerOrAdmin', () => {

--- a/test/unit/worlds-adapter.spec.ts
+++ b/test/unit/worlds-adapter.spec.ts
@@ -168,6 +168,119 @@ describe('worlds adapter', () => {
     })
   })
 
+  describe('when fetching world parcel permissions for an address', () => {
+    const worldName = 'myworld.dcl.eth'
+    const address = '0xabc123'
+    const permissionName = 'streaming'
+
+    describe('and the request is successful', () => {
+      describe('and the response includes parcels', () => {
+        let result: string[] | undefined
+
+        beforeEach(async () => {
+          mockFetch.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: jest.fn().mockResolvedValue({
+              total: 2,
+              parcels: ['0,0', '0,1']
+            })
+          })
+          result = await worldsComponent.getWorldParcelPermissions(address, worldName, permissionName)
+        })
+
+        it('should return the parcels from the response', () => {
+          expect(mockFetch.fetch).toHaveBeenCalledWith(
+            `${worldContentUrl}/world/${worldName}/permissions/${permissionName}/address/${address.toLowerCase()}/parcels`
+          )
+          expect(result).toEqual(['0,0', '0,1'])
+        })
+      })
+
+      describe('and the response has no parcels', () => {
+        let result: string[] | undefined
+
+        beforeEach(async () => {
+          mockFetch.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: jest.fn().mockResolvedValue({ total: 0, parcels: [] })
+          })
+          result = await worldsComponent.getWorldParcelPermissions(address, worldName, permissionName)
+        })
+
+        it('should return an empty array', () => {
+          expect(result).toEqual([])
+        })
+      })
+
+      describe('and the response parcels is undefined', () => {
+        let result: string[] | undefined
+
+        beforeEach(async () => {
+          mockFetch.fetch.mockResolvedValueOnce({
+            ok: true,
+            json: jest.fn().mockResolvedValue({ total: 0 })
+          })
+          result = await worldsComponent.getWorldParcelPermissions(address, worldName, permissionName)
+        })
+
+        it('should return an empty array', () => {
+          expect(result).toEqual([])
+        })
+      })
+    })
+
+    describe('and the request returns 404 (no permissions set for user)', () => {
+      let result: string[] | undefined
+
+      beforeEach(async () => {
+        mockFetch.fetch.mockResolvedValueOnce({
+          ok: false,
+          status: 404
+        })
+        result = await worldsComponent.getWorldParcelPermissions(address, worldName, permissionName)
+      })
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined()
+      })
+    })
+
+    describe('and the request fails with a non-404 status', () => {
+      beforeEach(() => {
+        mockFetch.fetch.mockResolvedValueOnce({
+          ok: false,
+          status: 500
+        })
+      })
+
+      it('should throw an error with the HTTP status', async () => {
+        await expect(worldsComponent.getWorldParcelPermissions(address, worldName, permissionName)).rejects.toThrow(
+          'Error getting '
+        )
+      })
+    })
+
+    describe('and the world name and address have uppercase letters', () => {
+      const uppercaseWorldName = 'MyWorld.DCL.ETH'
+      const uppercaseAddress = '0xABC123'
+
+      beforeEach(async () => {
+        mockFetch.fetch.mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ total: 0, parcels: [] })
+        })
+
+        await worldsComponent.getWorldParcelPermissions(uppercaseAddress, uppercaseWorldName, permissionName)
+      })
+
+      it('should lowercase world name and address in the URL', () => {
+        expect(mockFetch.fetch).toHaveBeenCalledWith(
+          `${worldContentUrl}/world/${uppercaseWorldName.toLowerCase()}/permissions/${permissionName}/address/${uppercaseAddress.toLowerCase()}/parcels`
+        )
+      })
+    })
+  })
+
   describe('when fetching parcel permission addresses', () => {
     const worldName = 'myworld.dcl.eth'
     const permissionName = 'deployment'


### PR DESCRIPTION
The worlds content server returns **404** when querying parcel-level permissions for a user that has no permissions configured (e.g. `GET .../permissions/streaming/address/{address}/parcels`). Previously we used `cachedFetch`, which throws on any non-2xx response, so this case surfaced as an error instead of a valid “no permissions” outcome.

We need to treat 404 as “no permissions set” and expose that to callers so they can treat it the same as “user has no parcels” (e.g. no parcel-specific streaming/deploy), without failing the request.

## How

- **Return `undefined` on 404**  
  `getWorldParcelPermissions` now returns `Promise<string[] | undefined>`: `undefined` means “no permissions / not found” (e.g. 404), and `string[]` means the listed parcels (or `[]` when the response is 200 but has no parcels).

- **Use raw `fetch` for this endpoint**  
  We no longer use `cachedFetch` for this call. The cached fetcher throws on `!response.ok`, so we can’t distinguish 404 from other errors. Using `fetch` directly lets us check `response.status`, return `undefined` only for 404, and still throw for other statuses (e.g. 500).

- **Callers treat `undefined` as no parcels**  
  In `scene-manager`, the results of `getWorldParcelPermissions` (streaming and deployment) are normalized with `?? []` before use (e.g. `.length`, `.some()`), so `undefined` is handled the same as “no parcels” and doesn’t change the permission logic beyond “no parcel-level permission.”

### Changes

- **`src/adapters/worlds.ts`**: `getWorldParcelPermissions` uses `fetch.fetch(url)`, returns `undefined` when `response.status === 404`, otherwise parses JSON and returns `result.parcels ?? []`; non-404 errors still throw.
- **`src/types/worlds.type.ts`**: `getWorldParcelPermissions` return type updated to `Promise<string[] | undefined>`.
- **`src/adapters/scene-manager.ts`**: Results of `getWorldParcelPermissions` are coerced with `?? []` before use so `undefined` is treated as no parcels.

### Tests

- **`test/unit/worlds-adapter.spec.ts`**: New “when fetching world parcel permissions for an address” block — successful response with parcels, empty parcels, undefined parcels, 404 returns `undefined`, non-404 throws; mocks in `beforeEach` per context.
- **`test/integration/scene-manager-component.spec.ts`**: New case where `getWorldParcelPermissions` is stubbed to resolve `undefined`, asserting the user has no extended permissions (same as no parcels). `createSceneManagerComponent` now receives `logs: stubComponents.logs` so the test satisfies the component type.
