### PR TITLE
fix: Resolve the world scene id before checking if it's banned

### DIFF
--- a/src/controllers/handlers/comms-scene-handler.ts
+++ b/src/controllers/handlers/comms-scene-handler.ts
@@ -35,11 +35,23 @@ export async function commsSceneHandler(
     throw new InvalidRequestError('Access denied, invalid signed-fetch request, no sceneId')
   }
 
+  // The client may send the world name as the sceneId instead of the actual content hash.
+  // Resolve the real sceneId once so both the ban check and room name use the same value.
+  let resolvedSceneId = sceneId
+  if (isWorld && sceneId?.endsWith('.eth')) {
+    try {
+      resolvedSceneId = await worlds.fetchWorldSceneId(realmName)
+    } catch (error) {
+      logger.error(`Failed to fetch scene ID for world ${realmName}: ${error}`)
+      throw new InvalidRequestError(`Failed to resolve scene ID for world ${realmName}`)
+    }
+  }
+
   // Check if user is banned from the scene
   if (!livekit.isLocalPreview(realmName)) {
     try {
       const isBanned = await sceneBans.isUserBanned(identity, {
-        sceneId,
+        sceneId: resolvedSceneId,
         realmName,
         parcel,
         isWorld
@@ -47,7 +59,7 @@ export async function commsSceneHandler(
 
       if (isBanned) {
         logger.warn(`Rejected connection from banned user: ${identity}`, {
-          sceneId: sceneId || '',
+          sceneId: resolvedSceneId || '',
           realmName,
           parcel,
           isWorld: String(isWorld)
@@ -61,7 +73,7 @@ export async function commsSceneHandler(
 
       // Ignore other errors
       logger.warn(`Error checking if user ${identity} is banned from scene: ${error}`, {
-        sceneId: sceneId || '',
+        sceneId: resolvedSceneId || '',
         realmName,
         parcel,
         isWorld: String(isWorld)
@@ -80,22 +92,9 @@ export async function commsSceneHandler(
       throw new UnauthorizedError('Access denied, you are not authorized to access this world')
     }
 
-    // The client may send the world name as the sceneId instead of the actual content hash.
-    // When that happens, the room name won't match the one used by ban/stream/cast operations
-    // (which use the real content hash). Fetch the real sceneId from the world's about endpoint
-    // to ensure all operations target the same LiveKit room.
-    let worldSceneId = sceneId!
-    if (sceneId!.endsWith('.eth')) {
-      try {
-        worldSceneId = await worlds.fetchWorldSceneId(realmName)
-      } catch (error) {
-        logger.error(`Failed to fetch scene ID for world ${realmName}: ${error}`)
-        throw new InvalidRequestError(`Failed to resolve scene ID for world ${realmName}`)
-      }
-    }
-    room = livekit.getWorldSceneRoomName(realmName, worldSceneId)
+    room = livekit.getWorldSceneRoomName(realmName, resolvedSceneId)
   } else {
-    room = livekit.getSceneRoomName(realmName, sceneId!)
+    room = livekit.getSceneRoomName(realmName, sceneId)
   }
 
   if (!permissions) {

--- a/test/integration/comms-scene-handler.spec.ts
+++ b/test/integration/comms-scene-handler.spec.ts
@@ -227,7 +227,7 @@ test('POST /get-scene-adapter', ({ components, stubComponents }) => {
           )
         })
 
-        it('should fetch the real sceneId and use it for the room name', async () => {
+        it('should fetch the real sceneId and use it for both the ban check and room name', async () => {
           const response = await makeRequest(
             components.localFetch,
             '/get-scene-adapter',
@@ -240,6 +240,7 @@ test('POST /get-scene-adapter', ({ components, stubComponents }) => {
 
           expect(response.status).toBe(200)
           expect(stubComponents.worlds.fetchWorldSceneId.calledWith('test-world.eth')).toBe(true)
+          expect(stubComponents.sceneBans.isUserBanned.firstCall.args[1].sceneId).toBe('bafkreiabcdef123')
           expect(stubComponents.livekit.getWorldSceneRoomName.calledWith('test-world.eth', 'bafkreiabcdef123')).toBe(
             true
           )
@@ -251,7 +252,7 @@ test('POST /get-scene-adapter', ({ components, stubComponents }) => {
           stubComponents.worlds.fetchWorldSceneId.rejects(new Error('HTTP 404'))
         })
 
-        it('should return 400', async () => {
+        it('should return 400 without reaching the ban check', async () => {
           const response = await makeRequest(
             components.localFetch,
             '/get-scene-adapter',
@@ -267,6 +268,35 @@ test('POST /get-scene-adapter', ({ components, stubComponents }) => {
           expect(body).toEqual({
             error: 'Failed to resolve scene ID for world test-world.eth'
           })
+          expect(stubComponents.sceneBans.isUserBanned.called).toBe(false)
+        })
+      })
+
+      describe('and the user is banned from the resolved world scene', () => {
+        beforeEach(() => {
+          stubComponents.worlds.fetchWorldSceneId.resolves('bafkreiabcdef123')
+          stubComponents.sceneBans.isUserBanned.resolves(true)
+        })
+
+        it('should resolve the sceneId, detect the ban, and reject with 403', async () => {
+          const response = await makeRequest(
+            components.localFetch,
+            '/get-scene-adapter',
+            {
+              method: 'POST',
+              metadata: worldNameAsSceneIdMetadata
+            },
+            owner
+          )
+
+          expect(response.status).toBe(403)
+          const body = await response.json()
+          expect(body).toEqual({
+            error: 'User is banned from this scene'
+          })
+          expect(stubComponents.worlds.fetchWorldSceneId.calledWith('test-world.eth')).toBe(true)
+          expect(stubComponents.sceneBans.isUserBanned.firstCall.args[1].sceneId).toBe('bafkreiabcdef123')
+          expect(stubComponents.worlds.hasWorldAccessPermission.called).toBe(false)
         })
       })
     })
@@ -301,6 +331,7 @@ test('POST /get-scene-adapter', ({ components, stubComponents }) => {
 
         expect(response.status).toBe(200)
         expect(stubComponents.worlds.fetchWorldSceneId.called).toBe(false)
+        expect(stubComponents.sceneBans.isUserBanned.firstCall.args[1].sceneId).toBe('bafkreiabcdef123')
         expect(stubComponents.livekit.getWorldSceneRoomName.calledWith('test-world.eth', 'bafkreiabcdef123')).toBe(true)
       })
     })


### PR DESCRIPTION
This PR moves up the resolution of the world scene id so it can be used when checking for banned users.