### PR TITLE
fix: Cast & Streaming for world admins

### DIFF
--- a/src/controllers/handlers/scene-stream-access-handlers/add-scene-stream-access-handler.ts
+++ b/src/controllers/handlers/scene-stream-access-handlers/add-scene-stream-access-handler.ts
@@ -20,7 +20,7 @@ export async function addSceneStreamAccessHandler(
     verification
   } = ctx
   const logger = logs.getLogger('add-scene-stream-access-handler')
-  const { getWorldScenePlace, getWorldByName, getPlaceByParcel } = places
+  const { getWorldScenePlace, getPlaceByParcel } = places
   const { isSceneOwnerOrAdmin } = sceneManager
   if (!verification?.auth) {
     logger.debug('Authentication required')
@@ -40,19 +40,14 @@ export async function addSceneStreamAccessHandler(
     throw new InvalidRequestError('Access denied, invalid signed-fetch request, no sceneId')
   }
 
-  // For worlds: use the world scene place for streaming key operations (scene-specific),
-  // but the world place for permission checks (world-wide admin/owner).
   let place: PlaceAttributes
-  let permissionPlace: PlaceAttributes
   if (isWorld) {
     place = await getWorldScenePlace(serverName, parcel)
-    permissionPlace = await getWorldByName(serverName)
   } else {
     place = await getPlaceByParcel(parcel)
-    permissionPlace = place
   }
 
-  const isOwnerOrAdmin = await isSceneOwnerOrAdmin(permissionPlace, authenticatedAddress)
+  const isOwnerOrAdmin = await isSceneOwnerOrAdmin(place, authenticatedAddress)
   if (!isOwnerOrAdmin) {
     logger.info(`Wallet ${authenticatedAddress} is not authorized to access this scene. Place ${place.id}`)
     throw new UnauthorizedError('Access denied, you are not authorized to access this scene')

--- a/src/controllers/handlers/scene-stream-access-handlers/list-scene-stream-access-handler.ts
+++ b/src/controllers/handlers/scene-stream-access-handlers/list-scene-stream-access-handler.ts
@@ -18,7 +18,7 @@ export async function listSceneStreamAccessHandler(
     verification
   } = ctx
   const logger = logs.getLogger('get-scene-stream-access-handler')
-  const { getWorldScenePlace, getWorldByName, getPlaceByParcel } = places
+  const { getWorldScenePlace, getPlaceByParcel } = places
   const { isSceneOwnerOrAdmin } = sceneManager
   if (!verification?.auth) {
     logger.debug('Authentication required')
@@ -38,19 +38,14 @@ export async function listSceneStreamAccessHandler(
     throw new InvalidRequestError('Access denied, invalid signed-fetch request, no sceneId')
   }
 
-  // For worlds: use the world scene place for streaming key operations (scene-specific),
-  // but the world place for permission checks (world-wide admin/owner).
   let place: PlaceAttributes
-  let permissionPlace: PlaceAttributes
   if (isWorld) {
     place = await getWorldScenePlace(serverName, parcel)
-    permissionPlace = await getWorldByName(serverName)
   } else {
     place = await getPlaceByParcel(parcel)
-    permissionPlace = place
   }
 
-  const isOwnerOrAdmin = await isSceneOwnerOrAdmin(permissionPlace, authenticatedAddress)
+  const isOwnerOrAdmin = await isSceneOwnerOrAdmin(place, authenticatedAddress)
   if (!isOwnerOrAdmin) {
     logger.info(`Wallet ${authenticatedAddress} is not authorized to access this scene. Place ${place.id}`)
     throw new UnauthorizedError('Access denied, you are not authorized to access this scene')

--- a/src/controllers/handlers/scene-stream-access-handlers/remove-scene-stream-access-handler.ts
+++ b/src/controllers/handlers/scene-stream-access-handlers/remove-scene-stream-access-handler.ts
@@ -25,7 +25,7 @@ export async function removeSceneStreamAccessHandler(
     verification
   } = ctx
   const logger = logs.getLogger('revoke-scene-stream-access-handler')
-  const { getWorldScenePlace, getWorldByName, getPlaceByParcel } = places
+  const { getWorldScenePlace, getPlaceByParcel } = places
   const { isSceneOwnerOrAdmin } = sceneManager
   if (!verification?.auth) {
     logger.debug('Authentication required')
@@ -45,19 +45,14 @@ export async function removeSceneStreamAccessHandler(
     throw new InvalidRequestError('Access denied, invalid signed-fetch request, no sceneId')
   }
 
-  // For worlds: use the world scene place for streaming key operations (scene-specific),
-  // but the world place for permission checks (world-wide admin/owner).
   let place: PlaceAttributes
-  let permissionPlace: PlaceAttributes
   if (isWorld) {
     place = await getWorldScenePlace(serverName, parcel)
-    permissionPlace = await getWorldByName(serverName)
   } else {
     place = await getPlaceByParcel(parcel)
-    permissionPlace = place
   }
 
-  const isOwnerOrAdmin = await isSceneOwnerOrAdmin(permissionPlace, authenticatedAddress)
+  const isOwnerOrAdmin = await isSceneOwnerOrAdmin(place, authenticatedAddress)
   if (!isOwnerOrAdmin) {
     logger.info(`Wallet ${authenticatedAddress} is not authorized to access this scene. Place ${place.id}`)
     throw new UnauthorizedError('Access denied, you are not authorized to access this scene')

--- a/src/controllers/handlers/scene-stream-access-handlers/reset-scene-stream-access-handler.ts
+++ b/src/controllers/handlers/scene-stream-access-handlers/reset-scene-stream-access-handler.ts
@@ -27,7 +27,7 @@ export async function resetSceneStreamAccessHandler(
     verification
   } = ctx
   const logger = logs.getLogger('reset-scene-stream-access-handler')
-  const { getWorldScenePlace, getWorldByName, getPlaceByParcel } = places
+  const { getWorldScenePlace, getPlaceByParcel } = places
   const { isSceneOwnerOrAdmin } = sceneManager
 
   if (!verification?.auth) {
@@ -49,19 +49,14 @@ export async function resetSceneStreamAccessHandler(
   }
 
   try {
-    // For worlds: use the world scene place for streaming key operations (scene-specific),
-    // but the world place for permission checks (world-wide admin/owner).
     let place: PlaceAttributes
-    let permissionPlace: PlaceAttributes
     if (isWorld) {
       place = await getWorldScenePlace(serverName, parcel)
-      permissionPlace = await getWorldByName(serverName)
     } else {
       place = await getPlaceByParcel(parcel)
-      permissionPlace = place
     }
 
-    const isOwnerOrAdmin = await isSceneOwnerOrAdmin(permissionPlace, authenticatedAddress)
+    const isOwnerOrAdmin = await isSceneOwnerOrAdmin(place, authenticatedAddress)
     if (!isOwnerOrAdmin) {
       logger.info(`Wallet ${authenticatedAddress} is not authorized to access this scene. Place ${place.id}`)
       throw new UnauthorizedError('Access denied, you are not authorized to access this scene')

--- a/src/logic/cast/cast.ts
+++ b/src/logic/cast/cast.ts
@@ -44,21 +44,14 @@ export function createCastComponent(
   async function generateStreamLink(params: GenerateStreamLinkParams): Promise<GenerateStreamLinkResult> {
     const { walletAddress, worldName, parcel, sceneId, realmName } = params
 
-    // Get place information
-    // For worlds: use the world scene place for streaming key generation (scene-specific),
-    // but the world place for permission checks (world-wide admin/owner).
     let place: PlaceAttributes
-    let permissionPlace: PlaceAttributes
     if (worldName) {
       place = await places.getWorldScenePlace(worldName, parcel)
-      permissionPlace = await places.getWorldByName(worldName)
     } else {
       place = await places.getPlaceByParcel(parcel)
-      permissionPlace = place
     }
 
-    // Verify the user is a scene admin (using world place for worlds)
-    const isAdmin = await sceneManager.isSceneOwnerOrAdmin(permissionPlace, walletAddress)
+    const isAdmin = await sceneManager.isSceneOwnerOrAdmin(place, walletAddress)
 
     if (!isAdmin) {
       logger.warn(

--- a/test/integration/scene-stream-access/add-scene-stream-access-handler.spec.ts
+++ b/test/integration/scene-stream-access/add-scene-stream-access-handler.spec.ts
@@ -90,12 +90,6 @@ test('GET /scene-stream-access - gets streaming access for scenes', ({ component
       owner: owner.authChain[0].payload
     } as PlaceAttributes)
 
-    stubComponents.places.getWorldByName.resolves({
-      id: 'world-place-id',
-      world_name: 'name.dcl.eth',
-      owner: owner.authChain[0].payload
-    } as PlaceAttributes)
-
     stubComponents.lands.getLandPermissions.resolves({
       owner: true,
       operator: false,
@@ -448,12 +442,6 @@ test('POST /scene-stream-access - adds streaming access for a scene', ({ compone
 
     stubComponents.places.getWorldScenePlace.resolves({
       id: placeWorldId,
-      world_name: 'name.dcl.eth',
-      owner: owner.authChain[0].payload
-    } as PlaceAttributes)
-
-    stubComponents.places.getWorldByName.resolves({
-      id: 'world-place-id',
       world_name: 'name.dcl.eth',
       owner: owner.authChain[0].payload
     } as PlaceAttributes)

--- a/test/integration/scene-stream-access/list-scene-stream-access-handler.spec.ts
+++ b/test/integration/scene-stream-access/list-scene-stream-access-handler.spec.ts
@@ -80,11 +80,6 @@ test('GET /scene-stream-access - lists streaming access for scenes', ({ componen
       world_name: 'name.dcl.eth',
       owner: owner.authChain[0].payload
     } as PlaceAttributes)
-    stubComponents.places.getWorldByName.resolves({
-      id: 'world-place-id',
-      world_name: 'name.dcl.eth',
-      owner: owner.authChain[0].payload
-    } as PlaceAttributes)
     stubComponents.lands.getLandPermissions.resolves({
       owner: true,
       operator: false,

--- a/test/integration/scene-stream-access/remove-scene-stream-access-handler.spec.ts
+++ b/test/integration/scene-stream-access/remove-scene-stream-access-handler.spec.ts
@@ -88,12 +88,6 @@ test('DELETE /scene-stream-access - removes streaming access for scenes', ({ com
       owner: owner.authChain[0].payload
     } as PlaceAttributes)
 
-    stubComponents.places.getWorldByName.resolves({
-      id: 'world-place-id',
-      world_name: 'name.dcl.eth',
-      owner: owner.authChain[0].payload
-    } as PlaceAttributes)
-
     stubComponents.sceneStreamAccessManager.getAccess.resolves(mockSceneStreamAccess)
     stubComponents.sceneStreamAccessManager.removeAccess.resolves()
     stubComponents.sceneManager.getUserScenePermissions.resolves({

--- a/test/integration/scene-stream-access/reset-scene-stream-access-handler.spec.ts
+++ b/test/integration/scene-stream-access/reset-scene-stream-access-handler.spec.ts
@@ -99,12 +99,6 @@ test('PUT /scene-stream-access - resets streaming access for scenes', ({ compone
       owner: owner.authChain[0].payload
     } as PlaceAttributes)
 
-    stubComponents.places.getWorldByName.resolves({
-      id: 'world-place-id',
-      world_name: 'name.dcl.eth',
-      owner: owner.authChain[0].payload
-    } as PlaceAttributes)
-
     stubComponents.lands.getLandPermissions.resolves({
       owner: true,
       operator: false,

--- a/test/unit/cast/generate-stream-link.spec.ts
+++ b/test/unit/cast/generate-stream-link.spec.ts
@@ -18,7 +18,6 @@ describe('when generating a stream link', () => {
   let mockPlaces: ReturnType<typeof createPlacesMockedComponent>
   let mockConfig: ReturnType<typeof createConfigMockedComponent>
   let mockPlace: PlaceAttributes
-  let mockWorldPlace: PlaceAttributes
   let mockWorldScenePlace: PlaceAttributes
 
   beforeEach(() => {
@@ -27,13 +26,6 @@ describe('when generating a stream link', () => {
       title: 'Test Place',
       owner: '0xowner123',
       positions: ['10,20']
-    })
-
-    mockWorldPlace = createMockedWorldPlace({
-      id: 'world-place-123',
-      title: 'Test World Place',
-      owner: '0xowner123',
-      world_name: 'test-world.dcl.eth'
     })
 
     mockWorldScenePlace = createMockedWorldPlace({
@@ -78,7 +70,6 @@ describe('when generating a stream link', () => {
 
     mockPlaces = createPlacesMockedComponent({
       getWorldScenePlace: jest.fn().mockResolvedValue(mockWorldScenePlace),
-      getWorldByName: jest.fn().mockResolvedValue(mockWorldPlace),
       getPlaceByParcel: jest.fn().mockResolvedValue(mockPlace)
     })
 
@@ -146,7 +137,6 @@ describe('when generating a stream link', () => {
     beforeEach(() => {
       mockSceneManager.isSceneOwnerOrAdmin.mockResolvedValue(true)
       mockPlaces.getWorldScenePlace.mockResolvedValue(mockWorldScenePlace)
-      mockPlaces.getWorldByName.mockResolvedValue(mockWorldPlace)
     })
 
     it('should get the world scene room with the scene id', async () => {
@@ -173,7 +163,7 @@ describe('when generating a stream link', () => {
       expect(mockPlaces.getWorldScenePlace).toHaveBeenCalledWith('test-world.dcl.eth', '0,0')
     })
 
-    it('should check admin permissions using the world place, not the world scene place', async () => {
+    it('should check admin permissions using the world scene place', async () => {
       await castComponent.generateStreamLink({
         walletAddress: '0xowner123',
         worldName: 'test-world.dcl.eth',
@@ -182,8 +172,7 @@ describe('when generating a stream link', () => {
         realmName: 'test-world.dcl.eth'
       })
 
-      expect(mockPlaces.getWorldByName).toHaveBeenCalledWith('test-world.dcl.eth')
-      expect(mockSceneManager.isSceneOwnerOrAdmin).toHaveBeenCalledWith(mockWorldPlace, '0xowner123')
+      expect(mockSceneManager.isSceneOwnerOrAdmin).toHaveBeenCalledWith(mockWorldScenePlace, '0xowner123')
     })
 
     it('should return the world scene place id', async () => {
@@ -203,7 +192,6 @@ describe('when generating a stream link', () => {
     beforeEach(() => {
       mockSceneManager.isSceneOwnerOrAdmin.mockResolvedValue(false)
       mockPlaces.getWorldScenePlace.mockResolvedValue(mockWorldScenePlace)
-      mockPlaces.getWorldByName.mockResolvedValue(mockWorldPlace)
     })
 
     it('should throw an UnauthorizedError', async () => {
@@ -326,7 +314,6 @@ describe('when generating a stream link', () => {
     beforeEach(() => {
       mockSceneManager.isSceneOwnerOrAdmin.mockResolvedValue(true)
       mockPlaces.getWorldScenePlace.mockResolvedValue(mockWorldScenePlace)
-      mockPlaces.getWorldByName.mockResolvedValue(mockWorldPlace)
     })
 
     it('should return the stream link details with place name and expiration information', async () => {


### PR DESCRIPTION
Scene admins granted permissions over a world scene were unable to use cast or manage stream access. The root cause was a place ID mismatch: admins are registered at the **scene level** (via `getWorldScenePlace`), but the permission checks in cast and all four stream-access handlers were running against the **world level** (via `getWorldByName`). These resolve to different place IDs, so `sceneAdminManager.isAdmin` never found the admin record and the request was rejected as unauthorized.

### How

Removed the `permissionPlace` / `getWorldByName` indirection from all affected handlers. For worlds, both the data operations (streaming keys, access records) and the permission check now use the same scene-level place returned by `getWorldScenePlace`. This is consistent with how `add-scene-admin-handler` stores admin records and aligns with the current model where admins, streaming, and other functionalities are all scene-bound.
