### PR TITLE
chore: list scene admins to be available to all scene participants

### DIFF
--- a/src/controllers/handlers/scene-admin-handlers/list-scene-admins-handler.ts
+++ b/src/controllers/handlers/scene-admin-handlers/list-scene-admins-handler.ts
@@ -7,21 +7,20 @@ import { PlaceAttributes } from '../../../types/places.type'
 export async function listSceneAdminsHandler(
   ctx: Pick<
     HandlerContextWithPath<
-      'logs' | 'config' | 'fetch' | 'sceneManager' | 'places' | 'names' | 'sceneAdmins' | 'landLease',
+      'logs' | 'config' | 'fetch' | 'places' | 'names' | 'sceneAdmins' | 'landLease',
       '/scene-admin'
     >,
     'components' | 'url' | 'verification' | 'request' | 'params'
   >
 ): Promise<IHttpServerComponent.IResponse> {
   const {
-    components: { logs, config, sceneManager, places, names, sceneAdmins, landLease },
+    components: { logs, config, places, names, sceneAdmins, landLease },
     url,
     verification
   } = ctx
 
   const logger = logs.getLogger('list-scene-admins-handler')
   const { getWorldScenePlace, getPlaceByParcel } = places
-  const { isSceneOwnerOrAdmin } = sceneManager
 
   if (!verification || verification?.auth === undefined) {
     logger.warn('Request without authentication')
@@ -47,15 +46,9 @@ export async function listSceneAdminsHandler(
     place = await getPlaceByParcel(parcel)
   }
 
-  // Skip admin check if request comes from authoritative server identity
-  if (!isAuthoritativeServerIdentity) {
-    const isOwnerOrAdmin = await isSceneOwnerOrAdmin(place, authenticatedAddress)
-
-    if (!isOwnerOrAdmin) {
-      logger.warn(`User ${authenticatedAddress} is not authorized to list administrators of entity ${place.id}`)
-      throw new UnauthorizedError('Only administrators or the owner can list administrators')
-    }
-  } else {
+  // Allow any authenticated scene participant to list admins.
+  // This enables all clients to validate admin identity for applying changes.
+  if (isAuthoritativeServerIdentity) {
     logger.debug(`Authoritative server ${authenticatedAddress} requesting scene admins for place ${place.id}`)
   }
 

--- a/test/integration/scene-admin/list-scene-admins-handler.spec.ts
+++ b/test/integration/scene-admin/list-scene-admins-handler.spec.ts
@@ -267,10 +267,8 @@ test('GET /scene-admin - lists all active administrators for scenes', ({ compone
     expect(response.status).toBe(200)
   })
 
-  it('returns 401 when user is not authorized', async () => {
+  it('returns 200 when user is not an admin (endpoint is public for all authenticated participants)', async () => {
     const { localFetch } = components
-
-    stubComponents.sceneManager.isSceneOwnerOrAdmin.resolves(false)
 
     const response = await makeRequest(
       localFetch,
@@ -282,9 +280,7 @@ test('GET /scene-admin - lists all active administrators for scenes', ({ compone
       nonOwner
     )
 
-    expect(response.status).toBe(401)
-    const body = await response.json()
-    expect(body).toHaveProperty('error')
+    expect(response.status).toBe(200)
   })
 
   it('returns 404 when place is not found', async () => {
@@ -908,11 +904,10 @@ test('GET /scene-admin - lists all active administrators for scenes', ({ compone
       stubComponents.config.getString.withArgs('AUTHORITATIVE_SERVER_ADDRESS').resolves(serverPublicKey)
     })
 
-    it('should return 401 even with server public key configured', async () => {
+    it('should return 200 even for non-server non-admin users (endpoint is public)', async () => {
       const { localFetch } = components
 
-      // User is NOT the server and is NOT owner/admin
-      stubComponents.sceneManager.isSceneOwnerOrAdmin.resolves(false)
+      stubComponents.landLease.getAuthorizations.resolves({ authorizations: [] })
 
       const response = await makeRequest(
         localFetch,
@@ -921,12 +916,10 @@ test('GET /scene-admin - lists all active administrators for scenes', ({ compone
           method: 'GET',
           metadata: metadataLand
         },
-        nonOwner // nonOwner's address doesn't match serverPublicKey
+        nonOwner
       )
 
-      expect(response.status).toBe(401)
-      // Verify isSceneOwnerOrAdmin WAS called since this is a regular user
-      expect(stubComponents.sceneManager.isSceneOwnerOrAdmin.called).toBe(true)
+      expect(response.status).toBe(200)
     })
   })
 })


### PR DESCRIPTION
Make `/scene-admin` list endpoint accessible to all authenticated scene participants. Previously restricted to admins and scene owners only. 
This enables scene clients to validate admin identity for securing admin-controlled component updates against unauthorized CRDT overwrites.