### PR TITLE
fix: use sceneId for LocalPreview room name

### DIFF
--- a/src/controllers/handlers/comms-scene-handler.ts
+++ b/src/controllers/handlers/comms-scene-handler.ts
@@ -95,7 +95,7 @@ export async function commsSceneHandler(
   }
 
   if (livekit.isLocalPreview(realmName)) {
-    room = `preview-${identity}`
+    room = `preview-${sceneId}`
 
     forPreview = true
   } else if (isWorld) {

--- a/src/controllers/handlers/comms-server-scene-handler.ts
+++ b/src/controllers/handlers/comms-server-scene-handler.ts
@@ -41,7 +41,7 @@ export async function commsServerSceneHandler(
   }
 
   if (livekit.isLocalPreview(realmName)) {
-    room = `preview-${identity}`
+    room = `preview-${sceneId}`
   } else if (isWorld) {
     // The caller may send the world name as the sceneId instead of the content hash.
     // Resolve the real sceneId from the world's about endpoint to ensure the room name


### PR DESCRIPTION
## Summary

Both `/get-scene-adapter` and `/get-server-scene-adapter` previously built the LocalPreview room name as `preview-${identity}`, which gave every preview client its own room and prevented them from connecting to each other. They now use `preview-${sceneId}` so all clients previewing the same scene land in the same room.

## What could break

- Any external tooling that assumed the LocalPreview room naming format `preview-<wallet>` will need to switch to `preview-<sceneId>`.
- Latent issue not addressed here: the `!isLocalPreview && !sceneId` guards in both handlers still allow LocalPreview through without a `sceneId`, which would now produce `preview-undefined`. Worth tightening in a follow-up so the guard requires `sceneId` unconditionally.

## How to test

- Run `yarn test` — all 79 suites should pass (verified locally).
- Manually: connect two preview clients to the same scene via a LocalPreview realm and confirm they see each other in the LiveKit room.