### PR TITLE
fix: drop local-preview fallback

### DIFF
--- a/src/controllers/handlers/comms-scene-handler.ts
+++ b/src/controllers/handlers/comms-scene-handler.ts
@@ -29,7 +29,7 @@ export async function commsSceneHandler(
 
   const isLocalPreview = livekit.isLocalPreview(realmName)
 
-  let forPreview = false
+  const forPreview = false
   let room: string
   const permissions: Permissions = {
     cast: [],
@@ -57,7 +57,7 @@ export async function commsSceneHandler(
 
   const isWorld = realmName.endsWith('.eth')
 
-  if (!isLocalPreview && !sceneId) {
+  if (!sceneId) {
     throw new InvalidRequestError('Access denied, invalid signed-fetch request, no sceneId')
   }
 
@@ -108,13 +108,7 @@ export async function commsSceneHandler(
   }
 
   if (isLocalPreview) {
-    if (resolvedSceneId) {
-      room = livekit.getSceneRoomName(realmName, resolvedSceneId)
-      forPreview = false
-    } else {
-      room = `preview-${identity}`
-      forPreview = true
-    }
+    room = livekit.getSceneRoomName(realmName, resolvedSceneId)
   } else if (isWorld) {
     const hasAccess = await worlds.hasWorldAccessPermission(identity, realmName)
 

--- a/test/integration/comms-scene-handler.spec.ts
+++ b/test/integration/comms-scene-handler.spec.ts
@@ -544,7 +544,20 @@ test('POST /get-scene-adapter', ({ components, stubComponents }) => {
         )
 
         expect(response.status).toBe(200)
+        const body = await response.json()
+        expect(body).toEqual({
+          adapter: 'livekit:wss://test-livekit-url?access_token=test-token'
+        })
         expect(stubComponents.livekit.getSceneRoomName.calledWith('LocalPreview', 'test-preview-scene')).toBe(true)
+        // cast.addPresenter internally appends to the 'presenters' metadata array
+        expect(
+          stubComponents.livekit.appendToRoomMetadataArray.calledWith(
+            'scene-LocalPreview:test-preview-scene',
+            'presenters',
+            owner.authChain[0].payload
+          )
+        ).toBe(true)
+        // generateCredentials signature: (identity, room, permissions, forPreview)
         expect(stubComponents.livekit.generateCredentials.firstCall.args[3]).toBe(false)
       })
 

--- a/test/integration/comms-scene-handler.spec.ts
+++ b/test/integration/comms-scene-handler.spec.ts
@@ -279,9 +279,7 @@ test('POST /get-scene-adapter', ({ components, stubComponents }) => {
       describe('and the world about endpoint returns the scene ID', () => {
         beforeEach(() => {
           stubComponents.worlds.fetchWorldSceneId.resolves('bafkreiabcdef123')
-          stubComponents.livekit.getWorldSceneRoomName.returns(
-            'world-prd-scene-room-test-world.eth-bafkreiabcdef123'
-          )
+          stubComponents.livekit.getWorldSceneRoomName.returns('world-prd-scene-room-test-world.eth-bafkreiabcdef123')
         })
 
         it('should fetch the real sceneId and use it for both the ban check and room name', async () => {
@@ -492,9 +490,7 @@ test('POST /get-scene-adapter', ({ components, stubComponents }) => {
         }
 
         stubComponents.worlds.hasWorldAccessPermission.resolves(true)
-        stubComponents.livekit.getWorldSceneRoomName.returns(
-          'world-prd-scene-room-test-world.eth-bafkreiabcdef123'
-        )
+        stubComponents.livekit.getWorldSceneRoomName.returns('world-prd-scene-room-test-world.eth-bafkreiabcdef123')
       })
 
       it('should use the sceneId as-is without fetching from the about endpoint', async () => {
@@ -512,6 +508,82 @@ test('POST /get-scene-adapter', ({ components, stubComponents }) => {
         expect(stubComponents.worlds.fetchWorldSceneId.called).toBe(false)
         expect(stubComponents.sceneBans.isUserBanned.firstCall.args[1].sceneId).toBe('bafkreiabcdef123')
         expect(stubComponents.livekit.getWorldSceneRoomName.calledWith('test-world.eth', 'bafkreiabcdef123')).toBe(true)
+      })
+    })
+  })
+
+  describe('when accessing a local preview realm', () => {
+    let previewMetadata: Metadata
+
+    beforeEach(() => {
+      previewMetadata = {
+        identity: owner.authChain[0].payload,
+        realmName: 'LocalPreview',
+        parcel: '10,20',
+        sceneId: 'test-preview-scene'
+      }
+
+      stubComponents.livekit.isLocalPreview.returns(true)
+      stubComponents.livekit.getSceneRoomName.returns('scene-LocalPreview:test-preview-scene')
+      stubComponents.livekit.generateCredentials.resolves({
+        url: 'wss://test-livekit-url',
+        token: 'test-token'
+      })
+    })
+
+    describe('and sceneId is provided', () => {
+      it('should build the room name from the scene id and generate credentials with forPreview=false', async () => {
+        const response = await makeRequest(
+          components.localFetch,
+          '/get-scene-adapter',
+          {
+            method: 'POST',
+            metadata: previewMetadata
+          },
+          owner
+        )
+
+        expect(response.status).toBe(200)
+        expect(stubComponents.livekit.getSceneRoomName.calledWith('LocalPreview', 'test-preview-scene')).toBe(true)
+        expect(stubComponents.livekit.generateCredentials.firstCall.args[3]).toBe(false)
+      })
+
+      it('should skip the scene ban check', async () => {
+        await makeRequest(
+          components.localFetch,
+          '/get-scene-adapter',
+          {
+            method: 'POST',
+            metadata: previewMetadata
+          },
+          owner
+        )
+
+        expect(stubComponents.sceneBans.isUserBanned.called).toBe(false)
+      })
+    })
+
+    describe('and sceneId is missing', () => {
+      it('should reject the request returning 400', async () => {
+        const response = await makeRequest(
+          components.localFetch,
+          '/get-scene-adapter',
+          {
+            method: 'POST',
+            metadata: {
+              identity: owner.authChain[0].payload,
+              realmName: 'LocalPreview',
+              parcel: '10,20'
+            }
+          },
+          owner
+        )
+
+        expect(response.status).toBe(400)
+        const body = await response.json()
+        expect(body).toEqual({
+          error: 'Access denied, invalid signed-fetch request, no sceneId'
+        })
       })
     })
   })


### PR DESCRIPTION
## Summary

Follow-up cleanup on `comms-scene-handler.ts` after #253 (which introduced the `preview-${sceneId}` contract for LocalPreview rooms). The handler still kept a nested conditional with a `preview-${identity}` fallback that is no longer reachable under the current contract and that the sibling `comms-server-scene-handler.ts` already treats as invalid. This PR makes the two handlers consistent and closes the latent gap flagged in #253 where a LocalPreview request without `sceneId` could slip past validation and produce a malformed room name.

## Changes

### 1. Tighten early sceneId validation

- **Before:** `if (!isLocalPreview && !sceneId) throw` — LocalPreview requests were allowed through without a `sceneId`.
- **After:** `if (!sceneId) throw` — missing `sceneId` is always a 400.

This also narrows `sceneId` from `string | undefined` to `string` for the rest of the function, which is what makes change (2) type-safe without any non-null assertions.

### 2. Collapse the LocalPreview room-name branch

```ts
// Before
if (isLocalPreview) {
  if (resolvedSceneId) {
    room = livekit.getSceneRoomName(realmName, resolvedSceneId)
    forPreview = false
  } else {
    room = `preview-${identity}`
    forPreview = true
  }
}

// After
if (isLocalPreview) {
  room = livekit.getSceneRoomName(realmName, resolvedSceneId)
}
```

The `else` branch was unreachable after change (1). `forPreview` is now always `false` and is demoted from `let` to `const`. The variable itself is left in place because it is still threaded into `livekit.generateCredentials(...)` — fully removing it would touch that signature and is left as a follow-up.

### 3. Integration coverage for LocalPreview

`test/integration/comms-scene-handler.spec.ts` previously had **zero** LocalPreview cases. This PR adds a `when accessing a local preview realm` block covering:

- **Happy path:** `getSceneRoomName` is called with the correct realm/sceneId and credentials are generated with `forPreview=false`.
- **Scene-ban check is skipped** in LocalPreview mode (the existing `!isLocalPreview` guard).
- **Missing `sceneId` in LocalPreview** now returns 400 with the expected error message.

## What could break

- Any LocalPreview client that relied on the `preview-${identity}` fallback when it failed to send `sceneId`. Post-#253 the expectation is already that clients send `sceneId`, and `/get-server-scene-adapter` already enforces it. A non-conforming client will now get a clean 400 instead of being silently routed to a per-identity room.

## How to test

- `yarn typecheck && yarn test` — all 85 suites / 1052 tests pass locally.
- `yarn lint:check && yarn format:check` on the touched files — clean.
- Manual: POST `/get-scene-adapter` with `realmName: "LocalPreview"` and no `sceneId` → expect 400; with a valid `sceneId` → expect 200 and a room name of `scene-LocalPreview:<sceneId>`.