### PR TITLE
fix: prevent 500 in /scene-admin when no profiles resolve

### DIFF
--- a/src/adapters/names.ts
+++ b/src/adapters/names.ts
@@ -3,7 +3,7 @@ import { EthAddress, Profile } from '@dcl/schemas'
 import { ensureSlashAtTheEnd } from '../logic/utils'
 import { AppComponents } from '../types'
 import { INamesComponent } from '../types/names.type'
-import { NameOwnerNotFoundError, ProfilesNotFoundError } from '../types/errors'
+import { NameOwnerNotFoundError } from '../types/errors'
 import { isErrorWithMessage } from '../logic/errors'
 
 const NAME_BY_ADDRESS_CACHE_MAX = 10000
@@ -93,9 +93,8 @@ export async function createNamesComponent(
    *
    * @param addresses - ETH addresses (any casing) to resolve.
    * @returns Object keyed by the input address (original casing preserved) to the
-   *   resolved display name. Addresses without a profile are absent from the map.
-   * @throws ProfilesNotFoundError if no addresses can be resolved (neither from cache
-   *   nor from the upstream response).
+   *   resolved display name. Addresses without a profile are absent from the map;
+   *   if none of the requested addresses have a profile, an empty object is returned.
    */
   async function getNamesFromAddresses(addresses: string[]): Promise<Record<string, string>> {
     if (addresses.length === 0) {
@@ -181,11 +180,6 @@ export async function createNamesComponent(
       if (name !== undefined) {
         result[inputAddress] = name
       }
-    }
-
-    if (Object.keys(result).length === 0) {
-      logger.info(`Profiles not found for ${addresses}`)
-      throw new ProfilesNotFoundError(`Profiles not found for ${addresses}`)
     }
 
     return result

--- a/src/logic/scene-bans/scene-bans.ts
+++ b/src/logic/scene-bans/scene-bans.ts
@@ -288,11 +288,11 @@ export function createSceneBansComponent(
 
     const bannedNames = await names.getNamesFromAddresses(addresses)
 
-    logger.info(`Successfully listed ${bannedNames.length} bans for place`)
+    logger.info(`Successfully listed ${Object.keys(bannedNames).length} bans for place`)
 
     const bans = addresses.map((address) => ({
       bannedAddress: address,
-      name: bannedNames[address]
+      name: bannedNames[address] ?? ''
     }))
 
     return { bans, total }

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -54,13 +54,6 @@ export class LandPermissionsNotFoundError extends Error {
   }
 }
 
-export class ProfilesNotFoundError extends Error {
-  constructor(message: string) {
-    super(message)
-    Error.captureStackTrace(this, this.constructor)
-  }
-}
-
 export class LivekitIngressNotFoundError extends Error {
   constructor(message: string) {
     super(message)

--- a/test/integration/scene-admin/list-scene-admins-handler.spec.ts
+++ b/test/integration/scene-admin/list-scene-admins-handler.spec.ts
@@ -666,6 +666,46 @@ test('GET /scene-admin - lists all active administrators for scenes', ({ compone
     expect(stubComponents.sceneAdmins.getAdminsAndExtraAddresses.calledOnce).toBe(true)
   })
 
+  it('returns 200 with empty names when no profiles are found for any admin', async () => {
+    const { localFetch } = components
+
+    const mockAdmin = {
+      id: '1',
+      place_id: placeId,
+      admin: admin.authChain[0].payload,
+      added_by: owner.authChain[0].payload,
+      created_at: Date.now(),
+      updated_at: Date.now(),
+      deleted_at: null,
+      active: true,
+      canBeRemoved: true,
+      name: ''
+    }
+
+    stubComponents.sceneAdmins.getAdminsAndExtraAddresses.resolves({
+      admins: new Set([mockAdmin]),
+      extraAddresses: new Set(),
+      addresses: new Set([mockAdmin.admin])
+    })
+
+    stubComponents.names.getNamesFromAddresses.resolves({})
+
+    const response = await makeRequest(
+      localFetch,
+      '/scene-admin',
+      {
+        method: 'GET',
+        metadata: metadataLand
+      },
+      owner
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(Array.isArray(body)).toBe(true)
+    expect(body).toEqual([mockAdmin])
+  })
+
   it('returns 500 when getAdminsAndExtraAddresses request fails', async () => {
     const { localFetch } = components
 

--- a/test/unit/names.spec.ts
+++ b/test/unit/names.spec.ts
@@ -3,7 +3,7 @@ import { createNamesComponent } from '../../src/adapters/names'
 import { cachedFetchComponent } from '../../src/adapters/fetch'
 import { ICachedFetchComponent } from '../../src/types/fetch.type'
 import { INamesComponent } from '../../src/types/names.type'
-import { NameOwnerNotFoundError, ProfilesNotFoundError } from '../../src/types/errors'
+import { NameOwnerNotFoundError } from '../../src/types/errors'
 import { createConfigMockedComponent } from '../mocks/config-mock'
 import { createLoggerMockedComponent } from '../mocks/logger-mock'
 
@@ -280,8 +280,8 @@ describe('names adapter', () => {
         })
       })
 
-      it('should throw ProfilesNotFoundError', async () => {
-        await expect(namesComponent.getNamesFromAddresses(['0xaaaa'])).rejects.toBeInstanceOf(ProfilesNotFoundError)
+      it('should resolve to an empty record', async () => {
+        await expect(namesComponent.getNamesFromAddresses(['0xaaaa'])).resolves.toEqual({})
       })
     })
 
@@ -309,22 +309,15 @@ describe('names adapter', () => {
 
     describe('and an address has no profile upstream', () => {
       let firstResult: Record<string, string>
-      let secondCallError: Error | null
+      let secondResult: Record<string, string>
 
       beforeEach(async () => {
-        secondCallError = null
-
         mockFetch.mockResolvedValueOnce({
           ok: true,
           json: jest.fn().mockResolvedValue([buildProfile('0xaaaa', 'alice')])
         })
         firstResult = await namesComponent.getNamesFromAddresses(['0xaaaa', '0xbbbb'])
-
-        try {
-          await namesComponent.getNamesFromAddresses(['0xbbbb'])
-        } catch (err) {
-          secondCallError = err as Error
-        }
+        secondResult = await namesComponent.getNamesFromAddresses(['0xbbbb'])
       })
 
       it('should resolve the address that was returned and skip the missing one', () => {
@@ -335,8 +328,8 @@ describe('names adapter', () => {
         expect(mockFetch).toHaveBeenCalledTimes(1)
       })
 
-      it('should throw ProfilesNotFoundError when the only address requested is negatively cached', () => {
-        expect(secondCallError).toBeInstanceOf(ProfilesNotFoundError)
+      it('should resolve to an empty record when the only address requested is negatively cached', () => {
+        expect(secondResult).toEqual({})
       })
     })
 


### PR DESCRIPTION
## Why

`/scene-admin` returns 500 for the entire request whenever every requested address comes back without a profile (for example, a single-admin scene where the admin has no profile entry). Production logs show:

```
Error: Profiles not found for 0x366ddc2999d759c6410e7a1be443ea44e5e98dfc
    at Object.getNamesFromAddresses (/app/dist/adapters/names.js:158:19)
    at async listSceneAdminsHandler (/app/dist/controllers/handlers/scene-admin-handlers/list-scene-admins-handler.js:57:22)
```

Root cause is in two places:

1. `getNamesFromAddresses` in `src/adapters/names.ts` threw `ProfilesNotFoundError` whenever its result map ended up empty — i.e., when no requested address had a profile.
2. The central `error-handler` had no mapping for `ProfilesNotFoundError`, so it fell through to the generic 500 branch.

The throw was never load-bearing. Every consumer of `getNamesFromAddresses` (the scene-admin handler, scene-bans logic) already coalesces missing names with `|| ''` or treats them as optional. The throw turned a benign "no addresses resolved" outcome into a fatal error that took the endpoint down for any place where the admin set didn't intersect the profile registry.

## How

- Removed the throw in `getNamesFromAddresses`. The function now returns the (possibly empty) record, which is what every caller already expects when an individual address has no profile. This collapses "some addresses unresolved" and "all addresses unresolved" into the same return shape — there was never a reason to treat them differently at the adapter boundary.
- Deleted the now-unused `ProfilesNotFoundError` class from `src/types/errors.ts` so the surface stays clean.
- Updated the two unit tests in `test/unit/names.spec.ts` that asserted the throw — they now assert an empty record (and that the negative cache still works on a subsequent call so we don't re-fetch).
- Added an integration test in `test/integration/scene-admin/list-scene-admins-handler.spec.ts` that pins the bug at the endpoint level: with `getNamesFromAddresses` stubbed to return `{}`, `/scene-admin` returns 200 with `name: ''` for the admin instead of 500.