### PR TITLE
fix: ignore stale participant_left after community voice rejoin

### DIFF
--- a/src/adapters/db/types.ts
+++ b/src/adapters/db/types.ts
@@ -24,6 +24,9 @@ export interface CommunityVoiceChatUser {
   isModerator: boolean
   joinedAt: number
   statusUpdatedAt: number
+  // The LiveKit participant session id of the user's current connection.
+  // Null while the user has not connected yet (or is reconnecting after a rejoin).
+  sid?: string | null
 }
 
 export interface IVoiceDBComponent {
@@ -123,8 +126,14 @@ export interface IVoiceDBComponent {
    * @param userAddress - The address of the user to update the status for.
    * @param roomName - The name of the community room.
    * @param status - The new status of the user.
+   * @param sid - The LiveKit session id to record for the user (optional).
    */
-  updateCommunityUserStatus: (userAddress: string, roomName: string, status: VoiceChatUserStatus) => Promise<void>
+  updateCommunityUserStatus: (
+    userAddress: string,
+    roomName: string,
+    status: VoiceChatUserStatus,
+    sid?: string
+  ) => Promise<void>
 
   /**
    * Gets users in a community voice chat room.

--- a/src/adapters/db/voice-db.ts
+++ b/src/adapters/db/voice-db.ts
@@ -288,29 +288,41 @@ export async function createVoiceDBComponent({
   ): Promise<void> {
     const now = Date.now()
 
-    // Use ON CONFLICT to handle insert or update in a single query
+    // Use ON CONFLICT to handle insert or update in a single query.
+    // sid is reset to NULL: this represents a brand new (pending) LiveKit session. It is
+    // filled in once the participant_joined webhook arrives for the new connection, which
+    // lets later "left" webhooks from the previous session be detected as stale.
     const query = SQL`
-      INSERT INTO community_voice_chat_users (address, room_name, is_moderator, status, joined_at, status_updated_at) 
-      VALUES (${userAddress}, ${roomName}, ${isModerator}, ${VoiceChatUserStatus.NotConnected}, ${now}, ${now}) 
-      ON CONFLICT (address, room_name) DO UPDATE SET 
-        status = ${VoiceChatUserStatus.NotConnected}, 
-        status_updated_at = ${now}, 
-        is_moderator = ${isModerator}
+      INSERT INTO community_voice_chat_users (address, room_name, is_moderator, status, joined_at, status_updated_at, sid)
+      VALUES (${userAddress}, ${roomName}, ${isModerator}, ${VoiceChatUserStatus.NotConnected}, ${now}, ${now}, ${null})
+      ON CONFLICT (address, room_name) DO UPDATE SET
+        status = ${VoiceChatUserStatus.NotConnected},
+        status_updated_at = ${now},
+        is_moderator = ${isModerator},
+        sid = ${null}
     `
     await database.query(query)
   }
 
   /**
    * Updates the status of a user in a community room.
+   * When a sid is provided, the user's current session id is updated as well (used when
+   * a participant_joined webhook confirms the connection for a given LiveKit session).
    */
   async function updateCommunityUserStatus(
     userAddress: string,
     roomName: string,
-    status: VoiceChatUserStatus
+    status: VoiceChatUserStatus,
+    sid?: string
   ): Promise<void> {
     const now = Date.now()
-    const query = SQL`UPDATE community_voice_chat_users 
-                      SET status = ${status}, status_updated_at = ${now} 
+    const query =
+      sid !== undefined
+        ? SQL`UPDATE community_voice_chat_users
+                      SET status = ${status}, status_updated_at = ${now}, sid = ${sid}
+                      WHERE address = ${userAddress} AND room_name = ${roomName}`
+        : SQL`UPDATE community_voice_chat_users
+                      SET status = ${status}, status_updated_at = ${now}
                       WHERE address = ${userAddress} AND room_name = ${roomName}`
     await database.query(query)
   }
@@ -327,7 +339,8 @@ export async function createVoiceDBComponent({
       isModerator: row.is_moderator,
       status: row.status,
       joinedAt: Number(row.joined_at),
-      statusUpdatedAt: Number(row.status_updated_at)
+      statusUpdatedAt: Number(row.status_updated_at),
+      sid: row.sid ?? null
     }))
   }
 

--- a/src/logic/livekit-webhook/event-handlers/participant-joined-handler.ts
+++ b/src/logic/livekit-webhook/event-handlers/participant-joined-handler.ts
@@ -65,7 +65,7 @@ export function createParticipantJoinedHandler(
 
     if (isVoiceChatRoom(webhookEvent)) {
       logger.debug(`Participant ${address} joined voice chat room ${room.name}`)
-      await voice.handleParticipantJoined(address, room.name)
+      await voice.handleParticipantJoined(address, room.name, webhookEvent.participant?.sid)
     }
   }
 

--- a/src/logic/livekit-webhook/event-handlers/participant-left-handler.ts
+++ b/src/logic/livekit-webhook/event-handlers/participant-left-handler.ts
@@ -71,10 +71,21 @@ export function createParticipantLeftHandler(
 
       if (isVoiceChatRoom(webhookEvent)) {
         const disconnectReason = webhookEvent.participant.disconnectReason
+        const sid = webhookEvent.participant.sid
+        // LiveKit sends the event timestamp as unix seconds (bigint); normalize it to ms.
+        // Fall back to "now" when it is missing so the timestamp guard simply does nothing.
+        const createdAt = webhookEvent.createdAt ? Number(webhookEvent.createdAt) : 0
+        const leaveEventTimeMs = createdAt > 0 ? (createdAt < 1e12 ? createdAt * 1000 : createdAt) : Date.now()
         logger.debug(
           `Participant ${userAddress} left voice chat room ${webhookEvent.room.name} with reason ${disconnectReason}`
         )
-        await components.voice.handleParticipantLeft(userAddress, webhookEvent.room.name, disconnectReason)
+        await components.voice.handleParticipantLeft(
+          userAddress,
+          webhookEvent.room.name,
+          disconnectReason,
+          sid,
+          leaveEventTimeMs
+        )
       }
     }
   }

--- a/src/logic/voice/types.ts
+++ b/src/logic/voice/types.ts
@@ -15,15 +15,24 @@ export interface IVoiceComponent {
    * @param userAddress - The address of the user that left the room.
    * @param roomName - The name of the room the user left.
    * @param disconnectReason - The reason the user left the room.
+   * @param sid - The LiveKit session id of the connection that left.
+   * @param leaveEventTimeMs - When the leave actually happened (LiveKit event time), in ms.
    */
-  handleParticipantLeft(userAddress: string, roomName: string, disconnectReason: DisconnectReason): Promise<void>
+  handleParticipantLeft(
+    userAddress: string,
+    roomName: string,
+    disconnectReason: DisconnectReason,
+    sid?: string,
+    leaveEventTimeMs?: number
+  ): Promise<void>
 
   /**
    * Handles the event when a participant joins a room.
    * @param userAddress - The address of the user that joined the room.
    * @param roomName - The name of the room the user joined.
+   * @param sid - The LiveKit session id of the joining connection.
    */
-  handleParticipantJoined(userAddress: string, roomName: string): Promise<void>
+  handleParticipantJoined(userAddress: string, roomName: string, sid?: string): Promise<void>
 
   /**
    * Generates credentials for a private voice chat room.

--- a/src/logic/voice/voice.ts
+++ b/src/logic/voice/voice.ts
@@ -8,6 +8,13 @@ import { CommunityVoiceChatAction } from '../../types/community-voice'
 import { isErrorWithMessage } from '../errors'
 import { Events, CommunityStreamingEndedEvent } from '@dcl/schemas'
 
+// Tolerance for the stale-leave timestamp guard. LiveKit event timestamps have
+// second precision (and come from a different clock), so we only treat the user's
+// state as "newer than the leave" when it is newer by more than this margin. This
+// biases towards processing genuine leaves (a real rejoin moves the state by much
+// more than a second) instead of leaving rooms/users stuck active.
+const STALE_LEAVE_SKEW_MS = 1000
+
 export function createVoiceComponent(
   components: Pick<AppComponents, 'voiceDB' | 'logs' | 'livekit' | 'analytics' | 'publisher'>
 ): IVoiceComponent {
@@ -89,11 +96,18 @@ export function createVoiceComponent(
    * Handles the event when a participant joins a COMMUNITY voice chat room.
    * @param userAddress - The address of the user that joined the room.
    * @param roomName - The name of the room the user joined.
+   * @param sid - The LiveKit session id of the joining connection.
    */
-  async function handleCommunityParticipantJoined(userAddress: string, roomName: string): Promise<void> {
-    logger.debug(`Community participant joined: ${userAddress} in room ${roomName}`)
-    // Simply update the user status to connected
-    await voiceDB.updateCommunityUserStatus(userAddress, roomName, VoiceChatUserStatus.Connected)
+  async function handleCommunityParticipantJoined(userAddress: string, roomName: string, sid?: string): Promise<void> {
+    logger.debug(`Community participant joined: ${userAddress} in room ${roomName} (sid: ${sid ?? 'unknown'})`)
+    if (!sid) {
+      // Without a session id the stale-leave session guard cannot work for this user and
+      // they fall back to the weaker timestamp guard. LiveKit normally always sends it.
+      logger.warn(`Community participant ${userAddress} joined room ${roomName} without a session id`)
+    }
+    // Update the user status to connected and record the session id so that a later
+    // "left" event coming from a previous session can be recognized as stale.
+    await voiceDB.updateCommunityUserStatus(userAddress, roomName, VoiceChatUserStatus.Connected, sid)
   }
 
   /**
@@ -138,11 +152,15 @@ export function createVoiceComponent(
    * @param userAddress - The address of the user that left the room.
    * @param roomName - The name of the room the user left.
    * @param disconnectReason - The reason the user left the room.
+   * @param sid - The LiveKit session id of the connection that left.
+   * @param leaveEventTimeMs - When the leave actually happened (LiveKit event time), in ms.
    */
   async function handleCommunityParticipantLeft(
     userAddress: string,
     roomName: string,
-    disconnectReason: DisconnectReason
+    disconnectReason: DisconnectReason,
+    sid?: string,
+    leaveEventTimeMs?: number
   ): Promise<void> {
     logger.debug(`Community participant left: ${userAddress} in room ${roomName}, reason: ${disconnectReason}`)
 
@@ -161,13 +179,36 @@ export function createVoiceComponent(
 
     // Update user status based on disconnect reason
     if (disconnectReason === DisconnectReason.CLIENT_INITIATED) {
-      await voiceDB.updateCommunityUserStatus(userAddress, roomName, VoiceChatUserStatus.Disconnected)
-
-      // Only check for room destruction when a moderator leaves voluntarily
-      // Get all users to check if the leaving user was a moderator
+      // Read the current room state before mutating it so we can detect stale events.
       const usersInRoom = await voiceDB.getCommunityUsersInRoom(roomName)
       const leavingUser = usersInRoom.find((user) => user.address === userAddress)
 
+      // Stale-event guards: a "left" webhook can arrive AFTER the user already left and
+      // rejoined with a brand new LiveKit session (e.g. leaving a stream and immediately
+      // rejoining). Acting on it would disconnect the user (or tear down the room they
+      // just reconnected to), leaving the client stuck on "Connecting".
+      if (leavingUser) {
+        // 1) Session guard: the room already tracks a different (newer) session for this user.
+        const isFromPreviousSession = !!sid && !!leavingUser.sid && leavingUser.sid !== sid
+        // 2) Timestamp guard (fallback while the new session has not registered its sid yet):
+        //    the user's state changed (well) after this leave actually happened => they rejoined.
+        const userStateIsNewerThanLeave =
+          !leavingUser.sid &&
+          leaveEventTimeMs !== undefined &&
+          leavingUser.statusUpdatedAt > leaveEventTimeMs + STALE_LEAVE_SKEW_MS
+
+        if (isFromPreviousSession || userStateIsNewerThanLeave) {
+          logger.info(
+            `Ignoring stale participant_left for ${userAddress} in room ${roomName}: a newer session is active ` +
+              `(leaving sid: ${sid ?? 'unknown'}, current sid: ${leavingUser.sid ?? 'none'})`
+          )
+          return
+        }
+      }
+
+      await voiceDB.updateCommunityUserStatus(userAddress, roomName, VoiceChatUserStatus.Disconnected)
+
+      // Only check for room destruction when a moderator leaves voluntarily.
       if (leavingUser?.isModerator) {
         logger.debug(`Moderator ${userAddress} left voluntarily, checking if room should be destroyed`)
 
@@ -204,12 +245,13 @@ export function createVoiceComponent(
    * Main handler that routes to private or community handlers based on room name.
    * @param userAddress - The address of the user that joined the room.
    * @param roomName - The name of the room the user joined.
+   * @param sid - The LiveKit session id of the joining connection.
    */
-  async function handleParticipantJoined(userAddress: string, roomName: string): Promise<void> {
+  async function handleParticipantJoined(userAddress: string, roomName: string, sid?: string): Promise<void> {
     if (roomName.startsWith('voice-chat-private-')) {
       await handlePrivateParticipantJoined(userAddress, roomName)
     } else if (roomName.startsWith('voice-chat-community-')) {
-      await handleCommunityParticipantJoined(userAddress, roomName)
+      await handleCommunityParticipantJoined(userAddress, roomName, sid)
     } else {
       logger.warn(`Unknown room type for participant joined: ${roomName}`)
     }
@@ -220,16 +262,20 @@ export function createVoiceComponent(
    * @param userAddress - The address of the user that left the room.
    * @param roomName - The name of the room the user left.
    * @param disconnectReason - The reason the user left the room.
+   * @param sid - The LiveKit session id of the connection that left.
+   * @param leaveEventTimeMs - When the leave actually happened (LiveKit event time), in ms.
    */
   async function handleParticipantLeft(
     userAddress: string,
     roomName: string,
-    disconnectReason: DisconnectReason
+    disconnectReason: DisconnectReason,
+    sid?: string,
+    leaveEventTimeMs?: number
   ): Promise<void> {
     if (roomName.startsWith('voice-chat-private-')) {
       await handlePrivateParticipantLeft(userAddress, roomName, disconnectReason)
     } else if (roomName.startsWith('voice-chat-community-')) {
-      await handleCommunityParticipantLeft(userAddress, roomName, disconnectReason)
+      await handleCommunityParticipantLeft(userAddress, roomName, disconnectReason, sid, leaveEventTimeMs)
     } else {
       logger.warn(`Unknown room type for participant left: ${roomName}`)
     }

--- a/src/migrations/1782134294072_add-sid-to-community-voice-chat.ts
+++ b/src/migrations/1782134294072_add-sid-to-community-voice-chat.ts
@@ -1,0 +1,18 @@
+import { MigrationBuilder } from 'node-pg-migrate'
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  // Track the LiveKit participant session id (sid) for each community voice chat user.
+  // This lets us tell apart a stale "participant_left" webhook coming from a previous
+  // session and the user's current session after an immediate leave + rejoin, so we
+  // don't disconnect them (or tear down the room) while they are reconnecting.
+  pgm.addColumn('community_voice_chat_users', {
+    sid: {
+      type: 'TEXT',
+      notNull: false
+    }
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn('community_voice_chat_users', 'sid')
+}

--- a/test/integration/livekit-webhook-handler.spec.ts
+++ b/test/integration/livekit-webhook-handler.spec.ts
@@ -130,7 +130,9 @@ test('POST /livekit-webhook', ({ components, spyComponents }) => {
           expect(handleParticipantLeftSpy).toHaveBeenCalledWith(
             callerAddress,
             webhookEvent.room.name,
-            DisconnectReason.DUPLICATE_IDENTITY
+            DisconnectReason.DUPLICATE_IDENTITY,
+            undefined,
+            expect.any(Number)
           )
 
           // Verify that the user's status wasn't changed in the database (no side effects)
@@ -571,7 +573,9 @@ test('POST /livekit-webhook', ({ components, spyComponents }) => {
         expect(handleParticipantLeftSpy).toHaveBeenCalledWith(
           memberAddress,
           webhookEvent.room.name,
-          DisconnectReason.CLIENT_INITIATED
+          DisconnectReason.CLIENT_INITIATED,
+          undefined,
+          expect.any(Number)
         )
 
         // Verify the database was updated correctly
@@ -601,7 +605,9 @@ test('POST /livekit-webhook', ({ components, spyComponents }) => {
           expect(handleParticipantLeftSpy).toHaveBeenCalledWith(
             moderatorAddress,
             webhookEvent.room.name,
-            DisconnectReason.CLIENT_INITIATED
+            DisconnectReason.CLIENT_INITIATED,
+            undefined,
+            expect.any(Number)
           )
 
           // Verify the room was destroyed in the database since no other moderators
@@ -635,7 +641,9 @@ test('POST /livekit-webhook', ({ components, spyComponents }) => {
           expect(handleParticipantLeftSpy).toHaveBeenCalledWith(
             moderatorAddress,
             webhookEvent.room.name,
-            DisconnectReason.CLIENT_INITIATED
+            DisconnectReason.CLIENT_INITIATED,
+            undefined,
+            expect.any(Number)
           )
 
           // Verify the room was NOT destroyed since there's another active moderator
@@ -676,7 +684,9 @@ test('POST /livekit-webhook', ({ components, spyComponents }) => {
           expect(handleParticipantLeftSpy).toHaveBeenCalledWith(
             memberAddress,
             webhookEvent.room.name,
-            DisconnectReason.MIGRATION
+            DisconnectReason.MIGRATION,
+            undefined,
+            expect.any(Number)
           )
 
           // Verify the database was updated correctly
@@ -706,7 +716,7 @@ test('POST /livekit-webhook', ({ components, spyComponents }) => {
         })
 
         expect(response.status).toBe(200)
-        expect(handleParticipantJoinedSpy).toHaveBeenCalledWith(memberAddress, webhookEvent.room.name)
+        expect(handleParticipantJoinedSpy).toHaveBeenCalledWith(memberAddress, webhookEvent.room.name, undefined)
 
         // Verify the database was updated correctly
         const usersInRoom = await components.voiceDB.getCommunityUsersInRoom(webhookEvent.room.name)
@@ -731,7 +741,7 @@ test('POST /livekit-webhook', ({ components, spyComponents }) => {
           })
 
           expect(response.status).toBe(200)
-          expect(handleParticipantJoinedSpy).toHaveBeenCalledWith(moderatorAddress, webhookEvent.room.name)
+          expect(handleParticipantJoinedSpy).toHaveBeenCalledWith(moderatorAddress, webhookEvent.room.name, undefined)
 
           // Verify the database was updated correctly
           const usersInRoom = await components.voiceDB.getCommunityUsersInRoom(webhookEvent.room.name)

--- a/test/unit/livekit-webhook-event-handlers/participant-joined-handler.spec.ts
+++ b/test/unit/livekit-webhook-event-handlers/participant-joined-handler.spec.ts
@@ -82,7 +82,8 @@ describe('Participant Joined Handler', () => {
           name: roomName
         },
         participant: {
-          identity: userAddress
+          identity: userAddress,
+          sid: 'PA_joined_session'
         }
       } as unknown as WebhookEvent
     })
@@ -110,7 +111,7 @@ describe('Participant Joined Handler', () => {
       it('should call the participant joined handler', async () => {
         await handler.handle(webhookEvent)
 
-        expect(handleParticipantJoinedMock).toHaveBeenCalledWith(userAddress, roomName)
+        expect(handleParticipantJoinedMock).toHaveBeenCalledWith(userAddress, roomName, 'PA_joined_session')
       })
 
       it('should call roomMetadataSync.updateRoomMetadataForRoom', async () => {
@@ -361,7 +362,11 @@ describe('Participant Joined Handler', () => {
       it('should call the voice handler for community voice chat rooms', async () => {
         await handler.handle(webhookEvent)
 
-        expect(handleParticipantJoinedMock).toHaveBeenCalledWith(userAddress, webhookEvent.room!.name)
+        expect(handleParticipantJoinedMock).toHaveBeenCalledWith(
+          userAddress,
+          webhookEvent.room!.name,
+          'PA_joined_session'
+        )
       })
     })
 
@@ -570,7 +575,7 @@ describe('Participant Joined Handler', () => {
           room: roomName,
           address: userAddress
         })
-        expect(handleParticipantJoinedMock).toHaveBeenCalledWith(userAddress, roomName)
+        expect(handleParticipantJoinedMock).toHaveBeenCalledWith(userAddress, roomName, 'PA_joined_session')
       })
     })
 

--- a/test/unit/livekit-webhook-event-handlers/participant-left-handler.spec.ts
+++ b/test/unit/livekit-webhook-event-handlers/participant-left-handler.spec.ts
@@ -82,7 +82,8 @@ describe('Participant Left Handler', () => {
         },
         participant: {
           identity: userAddress,
-          disconnectReason
+          disconnectReason,
+          sid: 'PA_left_session'
         }
       } as WebhookEvent
       getRoomMetadataFromRoomNameMock.mockReturnValueOnce(roomMetadata)
@@ -108,7 +109,13 @@ describe('Participant Left Handler', () => {
         it('should call the participant left handler and log the debug message', async () => {
           await handler.handle(webhookEvent)
 
-          expect(handleParticipantLeftMock).toHaveBeenCalledWith(userAddress, roomName, disconnectReason)
+          expect(handleParticipantLeftMock).toHaveBeenCalledWith(
+            userAddress,
+            roomName,
+            disconnectReason,
+            'PA_left_session',
+            expect.any(Number)
+          )
         })
       })
 
@@ -206,7 +213,13 @@ describe('Participant Left Handler', () => {
         it('should call the participant left handler for community voice chat rooms', async () => {
           await handler.handle(webhookEvent)
 
-          expect(handleParticipantLeftMock).toHaveBeenCalledWith(userAddress, webhookEvent.room!.name, disconnectReason)
+          expect(handleParticipantLeftMock).toHaveBeenCalledWith(
+            userAddress,
+            webhookEvent.room!.name,
+            disconnectReason,
+            'PA_left_session',
+            expect.any(Number)
+          )
         })
       })
 
@@ -406,7 +419,13 @@ describe('Participant Left Handler', () => {
           address: userAddress,
           reason: disconnectReason.toString()
         })
-        expect(handleParticipantLeftMock).toHaveBeenCalledWith(userAddress, roomName, disconnectReason)
+        expect(handleParticipantLeftMock).toHaveBeenCalledWith(
+          userAddress,
+          roomName,
+          disconnectReason,
+          'PA_left_session',
+          expect.any(Number)
+        )
       })
     })
 

--- a/test/unit/voice-logic.spec.ts
+++ b/test/unit/voice-logic.spec.ts
@@ -348,10 +348,15 @@ describe('Voice Logic Component', () => {
       voiceDB.updateCommunityUserStatus = updateCommunityUserStatusMock
     })
 
-    it('should update user status to connected', async () => {
-      await voiceComponent.handleParticipantJoined(userAddress, roomName)
+    it('should update user status to connected and record the session id', async () => {
+      await voiceComponent.handleParticipantJoined(userAddress, roomName, 'PA_session_1')
 
-      expect(updateCommunityUserStatusMock).toHaveBeenCalledWith(userAddress, roomName, VoiceChatUserStatus.Connected)
+      expect(updateCommunityUserStatusMock).toHaveBeenCalledWith(
+        userAddress,
+        roomName,
+        VoiceChatUserStatus.Connected,
+        'PA_session_1'
+      )
     })
   })
 
@@ -388,6 +393,151 @@ describe('Voice Logic Component', () => {
         expect(getCommunityUsersInRoomMock).not.toHaveBeenCalled()
         expect(deleteCommunityVoiceChatMock).not.toHaveBeenCalled()
         expect(deleteRoomMock).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the left event comes from a previous session (stale by sid)', () => {
+      beforeEach(() => {
+        // The user already left and rejoined: the room tracks a new session id, different
+        // from the one reported by this delayed leave event.
+        getCommunityUsersInRoomMock.mockResolvedValue([
+          {
+            address: userAddress,
+            roomName,
+            isModerator: true,
+            status: VoiceChatUserStatus.Connected,
+            joinedAt: Date.now(),
+            statusUpdatedAt: Date.now(),
+            sid: 'PA_new_session'
+          }
+        ])
+      })
+
+      it('should ignore the stale leave without disconnecting the user or destroying the room', async () => {
+        await voiceComponent.handleParticipantLeft(
+          userAddress,
+          roomName,
+          DisconnectReason.CLIENT_INITIATED,
+          'PA_old_session',
+          Date.now()
+        )
+
+        expect(updateCommunityUserStatusMock).not.toHaveBeenCalled()
+        expect(deleteCommunityVoiceChatMock).not.toHaveBeenCalled()
+        expect(deleteRoomMock).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the user state changed after the leave happened (stale by timestamp)', () => {
+      let leaveEventTimeMs: number
+
+      beforeEach(() => {
+        leaveEventTimeMs = 1_000_000
+        // The user rejoined (new session sid not registered yet) and their status was
+        // updated AFTER the moment this leave actually happened.
+        getCommunityUsersInRoomMock.mockResolvedValue([
+          {
+            address: userAddress,
+            roomName,
+            isModerator: true,
+            status: VoiceChatUserStatus.NotConnected,
+            joinedAt: leaveEventTimeMs + 5_000,
+            statusUpdatedAt: leaveEventTimeMs + 5_000,
+            sid: null
+          }
+        ])
+      })
+
+      it('should ignore the stale leave without disconnecting the user or destroying the room', async () => {
+        await voiceComponent.handleParticipantLeft(
+          userAddress,
+          roomName,
+          DisconnectReason.CLIENT_INITIATED,
+          undefined,
+          leaveEventTimeMs
+        )
+
+        expect(updateCommunityUserStatusMock).not.toHaveBeenCalled()
+        expect(deleteCommunityVoiceChatMock).not.toHaveBeenCalled()
+        expect(deleteRoomMock).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the user left within the timestamp skew window (genuine immediate leave)', () => {
+      let leaveEventTimeMs: number
+
+      beforeEach(() => {
+        leaveEventTimeMs = 1_000_000
+        // sid not registered and the state was last updated just before the leave (within
+        // the skew tolerance): this is a genuine leave, not a stale event, so it must be
+        // processed normally rather than ignored.
+        getCommunityUsersInRoomMock.mockResolvedValue([
+          {
+            address: userAddress,
+            roomName,
+            isModerator: true,
+            status: VoiceChatUserStatus.Connected,
+            joinedAt: leaveEventTimeMs - 5_000,
+            statusUpdatedAt: leaveEventTimeMs - 5_000,
+            sid: null
+          }
+        ])
+        getCommunityVoiceChatParticipantCountMock.mockResolvedValue(1)
+        publishMessageMock.mockResolvedValue(undefined)
+      })
+
+      it('should process the leave and destroy the room when the last moderator leaves', async () => {
+        await voiceComponent.handleParticipantLeft(
+          userAddress,
+          roomName,
+          DisconnectReason.CLIENT_INITIATED,
+          undefined,
+          leaveEventTimeMs
+        )
+
+        expect(updateCommunityUserStatusMock).toHaveBeenCalledWith(
+          userAddress,
+          roomName,
+          VoiceChatUserStatus.Disconnected
+        )
+        expect(deleteRoomMock).toHaveBeenCalledWith(roomName)
+        expect(deleteCommunityVoiceChatMock).toHaveBeenCalledWith(roomName)
+      })
+    })
+
+    describe('when the left event matches the current session (not stale)', () => {
+      beforeEach(() => {
+        getCommunityUsersInRoomMock.mockResolvedValue([
+          {
+            address: userAddress,
+            roomName,
+            isModerator: true,
+            status: VoiceChatUserStatus.Connected,
+            joinedAt: Date.now(),
+            statusUpdatedAt: Date.now(),
+            sid: 'PA_current_session'
+          }
+        ])
+        getCommunityVoiceChatParticipantCountMock.mockResolvedValue(1)
+        publishMessageMock.mockResolvedValue(undefined)
+      })
+
+      it('should disconnect the user and destroy the room when the last moderator leaves', async () => {
+        await voiceComponent.handleParticipantLeft(
+          userAddress,
+          roomName,
+          DisconnectReason.CLIENT_INITIATED,
+          'PA_current_session',
+          Date.now()
+        )
+
+        expect(updateCommunityUserStatusMock).toHaveBeenCalledWith(
+          userAddress,
+          roomName,
+          VoiceChatUserStatus.Disconnected
+        )
+        expect(deleteRoomMock).toHaveBeenCalledWith(roomName)
+        expect(deleteCommunityVoiceChatMock).toHaveBeenCalledWith(roomName)
       })
     })
 


### PR DESCRIPTION
Fixes the "stream stuck on Connecting after rejoining immediately" bug.

Relates to decentraland/unity-explorer#9003

## Problem

Community voice chat state in `community_voice_chat_users` is keyed only by `(address, room_name)` with no LiveKit session tracking. When a user leaves a stream and immediately rejoins, the delayed `participant_left` webhook from the **previous** LiveKit session arrives **after** the user has already reconnected and:

- overwrites their status to `Disconnected`, and
- if they are the only moderator (the stream host — the reported scenario), runs the room-destruction path and deletes the LiveKit room + DB records, tearing down the connection they just re-established.

The social-service polling then sees the room inactive and emits `COMMUNITY_VOICE_CHAT_ENDED`, while the client stays on "Connecting" forever (only an app restart clears it). Extra interactions before leaving (raise hand / promote) add LiveKit/webhook latency, widening the race — hence the ~100% repro on immediate rejoin.

## Changes

- Add a nullable `sid` (LiveKit participant session id) column to `community_voice_chat_users` (migration).
- Record the `sid` together with the `connected` status on `participant_joined`; reset it to `NULL` on (re)join so a pending session is recognizable.
- In `handleCommunityParticipantLeft` (only the `CLIENT_INITIATED` path), ignore stale events before mutating state or destroying the room:
  - **Session guard**: the row already tracks a different (newer) `sid` than the one that left.
  - **Timestamp guard** (fallback while the new session's `sid` is not registered yet): the user's state was updated more than `STALE_LEAVE_SKEW_MS` after the leave actually happened (LiveKit event time), i.e. they already rejoined. The skew tolerance biases toward processing genuine leaves rather than leaving rooms stuck active.
- Genuine leaves (matching session / no newer state) keep the existing behaviour, including last-moderator room destruction.

This mirrors the existing `DUPLICATE_IDENTITY` ignore and fixes the whole class of "stale webhook overwrites fresher state".

## Test plan

- [x] `yarn build` / `yarn typecheck`
- [x] `yarn test` (unit) — 616 passing, incl. new cases: stale-by-sid, stale-by-timestamp, genuine-immediate-leave (within skew), and not-stale
- [x] Updated `participant_joined` / `participant_left` handler + integration spies for the new args
- [ ] Integration suite (Postgres/Redis) — runs in CI