### PR TITLE
fix: allow community voice rejoin after speaker promotion

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@well-known-components/tracer-component": "^1.2.0",
     "cron": "^4.1.3",
     "dcl-catalyst-client": "^22.0.0",
-    "livekit-server-sdk": "^2.12.0",
+    "livekit-server-sdk": "2.15.4",
     "lru-cache": "^10.1.0",
     "sql-template-strings": "^2.2.2"
   }

--- a/src/adapters/livekit.ts
+++ b/src/adapters/livekit.ts
@@ -99,9 +99,36 @@ export async function createLivekitComponent(
       canPublishSources
     })
 
+    const jwt = await token.toJwt()
+
+    if (roomId.startsWith(COMMUNITY_VOICE_CHAT_ROOM_PREFIX)) {
+      try {
+        const encodedPayload = jwt.split('.')[1]
+        const payload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8')) as {
+          nbf?: number
+          exp?: number
+        }
+
+        logger.info('Generated community voice chat token', {
+          identity,
+          roomId,
+          nbf: payload.nbf,
+          exp: payload.exp,
+          canPublish: String(permissions.canPublish ?? true),
+          forPreview: String(forPreview)
+        })
+      } catch (error) {
+        logger.warn('Failed to inspect generated community voice chat token timestamps', {
+          identity,
+          roomId,
+          error: isErrorWithMessage(error) ? error.message : 'Unknown error'
+        })
+      }
+    }
+
     return {
       url: settings.host,
-      token: await token.toJwt()
+      token: jwt
     }
   }
 

--- a/test/unit/livekit-adapter.spec.ts
+++ b/test/unit/livekit-adapter.spec.ts
@@ -1,5 +1,12 @@
-import { RoomServiceClient, Room, AccessToken, IngressClient, WebhookReceiver, ParticipantInfo } from 'livekit-server-sdk'
-import { createLivekitComponent } from '../../src/adapters/livekit'
+import {
+  RoomServiceClient,
+  Room,
+  AccessToken,
+  IngressClient,
+  WebhookReceiver,
+  ParticipantInfo
+} from 'livekit-server-sdk'
+import { COMMUNITY_VOICE_CHAT_ROOM_PREFIX, createLivekitComponent } from '../../src/adapters/livekit'
 import { ILivekitComponent } from '../../src/types/livekit.type'
 
 let livekitComponent: ILivekitComponent
@@ -521,6 +528,43 @@ describe('when generating credentials', () => {
       expect(result.token).toBe('mock-jwt-token')
       expect(accessTokenToJwtSpy).toHaveBeenCalled()
     })
+
+    it('should generate tokens whose nbf matches their issuance time', async () => {
+      accessTokenToJwtSpy.mockRestore()
+      const beforeIssuance = Math.floor(Date.now() / 1000)
+
+      const result = await livekitComponent.generateCredentials(identity, roomId, permissions, false)
+      const afterIssuance = Math.floor(Date.now() / 1000)
+      const payload = JSON.parse(Buffer.from(result.token.split('.')[1], 'base64url').toString('utf8')) as {
+        nbf?: number
+      }
+
+      expect(payload.nbf).toBeGreaterThanOrEqual(beforeIssuance)
+      expect(payload.nbf).toBeLessThanOrEqual(afterIssuance)
+    })
+
+    it('should log community token timestamps without exposing the token', async () => {
+      const now = Math.floor(Date.now() / 1000)
+      const payload = Buffer.from(JSON.stringify({ nbf: now, exp: now + 300 })).toString('base64url')
+      accessTokenToJwtSpy.mockResolvedValue(`header.${payload}.signature`)
+
+      await livekitComponent.generateCredentials(
+        identity,
+        `${COMMUNITY_VOICE_CHAT_ROOM_PREFIX}-community-id`,
+        permissions,
+        false
+      )
+
+      expect(loggerInfoSpy).toHaveBeenCalledWith('Generated community voice chat token', {
+        identity,
+        roomId: `${COMMUNITY_VOICE_CHAT_ROOM_PREFIX}-community-id`,
+        nbf: now,
+        exp: now + 300,
+        canPublish: 'true',
+        forPreview: 'false'
+      })
+      expect(JSON.stringify(loggerInfoSpy.mock.calls)).not.toContain('signature')
+    })
   })
 
   describe('for preview environment', () => {
@@ -1041,10 +1085,7 @@ describe('when removing a participant from all rooms', () => {
 
   describe('when no room contains the target participant', () => {
     beforeEach(() => {
-      listRoomsSpy.mockResolvedValue([
-        { name: 'scene-realm1:scene1' } as Room,
-        { name: 'island-island1' } as Room
-      ])
+      listRoomsSpy.mockResolvedValue([{ name: 'scene-realm1:scene1' } as Room, { name: 'island-island1' } as Room])
       // Both rooms have other participants but not the target one.
       listParticipantsSpy.mockResolvedValue([{ identity: '0xsomeoneelse' } as ParticipantInfo])
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,10 +1080,15 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bufbuild/protobuf@^1.10.0", "@bufbuild/protobuf@^1.7.2":
+"@bufbuild/protobuf@^1.10.0":
   version "1.10.0"
   resolved "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz"
   integrity sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==
+
+"@bufbuild/protobuf@^1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@bufbuild/protobuf/-/protobuf-1.10.1.tgz#1d76d15290c0212076c15ede94d15157ba0c6344"
+  integrity sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
@@ -1609,10 +1614,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@livekit/protocol@^1.36.1":
-  version "1.36.1"
-  resolved "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.36.1.tgz"
-  integrity sha512-nN3QnITAQ5yXk7UKfotH7CRWIlEozNWeKVyFJ0/+dtSzvWP/ib+10l1DDnRYi3A1yICJOGAKFgJ5d6kmi1HCUA==
+"@livekit/protocol@^1.46.3":
+  version "1.48.0"
+  resolved "https://registry.yarnpkg.com/@livekit/protocol/-/protocol-1.48.0.tgz#74d44d65fb049e33c927a6ed46b673cb0386b9ab"
+  integrity sha512-fYHYgltH6YavAsokl3qsHLkBdQeKCl4UORVTub5crS3t8JtKFZ0uinHDFQ+XXdNKS6Ub9gcOjV+UHcDiqnWXoQ==
   dependencies:
     "@bufbuild/protobuf" "^1.10.0"
 
@@ -4614,13 +4619,13 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-livekit-server-sdk@^2.12.0:
-  version "2.12.0"
-  resolved "https://registry.npmjs.org/livekit-server-sdk/-/livekit-server-sdk-2.12.0.tgz"
-  integrity sha512-6i2l0Ja1yhYvCXqU9wZ3SlWPEm1pYXpSJbpmT3sN0UWS61+jF6qkVY4AeSRQ53w5zrgzLBIyDwooBEMxz7XyMw==
+livekit-server-sdk@2.15.4:
+  version "2.15.4"
+  resolved "https://registry.yarnpkg.com/livekit-server-sdk/-/livekit-server-sdk-2.15.4.tgz#01dcbd4fe79ce822f536bd1f876c2f6f9d8d7d01"
+  integrity sha512-L/Ynu5zH1Qjfifmk3LnymL2JpvtisMFCM2wf7iM6H42WZRx6yvRECXa0hiK9/zi7br8d1x/a7fQIw1yJ/bneOA==
   dependencies:
-    "@bufbuild/protobuf" "^1.7.2"
-    "@livekit/protocol" "^1.36.1"
+    "@bufbuild/protobuf" "^1.10.1"
+    "@livekit/protocol" "^1.46.3"
     camelcase-keys "^9.0.0"
     jose "^5.1.2"
 


### PR DESCRIPTION
# Fix community voice rejoin after speaker promotion

## Summary

Upgrades `livekit-server-sdk` from `2.12.0` to `2.15.4` so newly generated LiveKit JWTs contain a real `nbf` (not-before) timestamp. It also adds safe diagnostics for community voice tokens and a regression test for the timestamp.

No JWT value, signature, API key, or API secret is written to logs.

## Problem

A community voice participant could join as a listener, become a speaker, leave the voice chat, and then fail every attempt to rejoin. LiveKit rejected the newly requested credential with:

```text
401 Unauthorized - invalid token: revoked
```

The Explorer then remained in its Connecting state because it did not recover correctly from that connection failure. Explorer error handling is a separate client-side issue and is not part of this PR.

## Root cause

Promoting a participant calls LiveKit's `UpdateParticipant` API to change that participant's permissions. LiveKit Cloud revokes tokens issued before a permission update so an old credential cannot be reused with stale permissions.

LiveKit uses the JWT `nbf` claim to determine whether a credential predates the latest revocation for a participant. `livekit-server-sdk@2.12.0` generated tokens with:

```json
{
  "nbf": 0
}
```

`nbf: 0` represents the Unix epoch. Consequently, even a new token requested after promotion appeared to LiveKit as if it had been issued before the permission-change revocation and was rejected.

`livekit-server-sdk@2.15.4` sets `nbf` to the token issuance time. A token created after the permission update can therefore be distinguished from the revoked credential and accepted for rejoin.

## Failure sequence

```text
User joins community voice as listener
  -> Gatekeeper issues token A with canPublish=false
  -> Moderator promotes user to speaker
  -> LiveKit updates permissions and revokes older credentials
  -> User leaves
  -> Gatekeeper issues token B for rejoin
  -> token B has nbf=0 with SDK 2.12.0
  -> LiveKit considers token B older than the revocation
  -> LiveKit rejects the connection with 401 revoked
```

## Changes

- Pin `livekit-server-sdk` to `2.15.4`.
- Update the Yarn lockfile and transitive LiveKit protocol dependencies.
- Log the following fields when issuing a community voice token:
  - participant identity;
  - room ID;
  - `nbf`;
  - `exp`;
  - publish permission;
  - preview/production selection.
- Add a regression test asserting that `nbf` is within the token-generation time window.
- Add a test ensuring diagnostics do not log the JWT.

## Expected diagnostic

```text
Generated community voice chat token {
  identity: "0x...",
  roomId: "voice-chat-community-...",
  nbf: 1782135000,
  exp: 1782135300,
  canPublish: false,
  forPreview: false
}
```

The important validation is that `nbf` is close to the current Unix timestamp and is not `0`.

## Validation plan

1. Start or join a community voice chat.
2. Promote the test participant from listener to speaker.
3. Confirm the permission update succeeds.
4. Leave the voice chat.
5. Rejoin the same active room.
6. Confirm the generated token log has a current `nbf`.
7. Confirm LiveKit accepts the connection without `401 invalid token: revoked`.

Automated coverage verifies the SDK-generated `nbf` and that the diagnostic does not expose the token.

## Scope

This PR fixes credential validity at the Gatekeeper/LiveKit boundary. A follow-up Explorer change should ensure a LiveKit 401 exits Connecting, exposes an error/cancel action, and does not wait indefinitely during room activation.
