### PR TITLE
feat: bump @dcl/crypto-middleware to 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@dcl/analytics-component": "^1.0.3",
     "@dcl/core-commons": "^0.10.1",
     "@dcl/crypto": "^3.4.5",
-    "@dcl/crypto-middleware": "^4.0.0",
+    "@dcl/crypto-middleware": "^4.1.0",
     "@dcl/features-component": "^1.0.1",
     "@dcl/http-commons": "^2.0.0",
     "@dcl/http-requests-logger-component": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1132,6 +1132,14 @@
     "@dcl/core-commons" "^0.10.0"
     "@dcl/crypto" "3.7.0"
 
+"@dcl/crypto-middleware@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@dcl/crypto-middleware/-/crypto-middleware-4.1.0.tgz#85b946c2627d4fbb3a91795fd78109f5cccba1e4"
+  integrity sha512-F9MVyxnLFaLJSyo5o6MtsGTDiQ1r4VqCKuFkaEPcq2JFyI6W4ftIRaKIj7hLb65PP/ywm3FkQrizSJ+6MhWpZw==
+  dependencies:
+    "@dcl/core-commons" "^0.10.0"
+    "@dcl/crypto" "3.7.0"
+
 "@dcl/crypto@3.7.0":
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/@dcl/crypto/-/crypto-3.7.0.tgz#2436370e591ea269da4806ee800e8eec21ff2168"


### PR DESCRIPTION
## what

bump `@dcl/crypto-middleware` from `^4.0.0` to `^4.1.0` to pick up the latest published release (4.1.0).

## notes

follow-up to the recently merged `@well-known-components` → `@dcl` migration; `@dcl/crypto-middleware@4.1.0` was published after those PRs merged, so the dependency is updated here on its own.

## verification

- install refreshes the lockfile to `@dcl/crypto-middleware@4.1.0`.
- the typescript build passes.
