### PR TITLE
fix: suppress comms events for preview realms regardless of ALLOW_LOCAL_PREVIEW

### DIFF
--- a/src/adapters/livekit.ts
+++ b/src/adapters/livekit.ts
@@ -135,13 +135,34 @@ export async function createLivekitComponent(
   const LOCAL_PREVIEW_REALM_NAMES = ['localpreview', 'preview']
 
   /**
-   * Checks if the given realm name indicates a local preview environment.
-   * Returns false when the ALLOW_LOCAL_PREVIEW config flag is not enabled.
+   * Checks if the given realm name is a local preview realm, based on its name alone.
+   *
+   * Unlike {@link isLocalPreview}, this does NOT consult the ALLOW_LOCAL_PREVIEW
+   * config flag, so it returns the same answer in every environment. Use it where
+   * a preview realm must be recognized regardless of configuration — e.g. to skip
+   * publishing analytics events for Creator Hub / local development sessions, which
+   * connect to the production comms infrastructure and therefore reach this service
+   * with ALLOW_LOCAL_PREVIEW disabled. It grants no access or privileges, so it is
+   * safe to evaluate even when local preview support is turned off.
+   */
+  function isPreviewRealmName(realmName: string | undefined): boolean {
+    if (!realmName) return false
+    return LOCAL_PREVIEW_REALM_NAMES.includes(realmName.toLowerCase())
+  }
+
+  /**
+   * Checks if the given realm name indicates a local preview environment AND local
+   * preview support is enabled for this service.
+   *
+   * Returns false when the ALLOW_LOCAL_PREVIEW config flag is not set to 'true'. This
+   * gate is a security control: callers use it to bypass authentication, scene-ban
+   * enforcement and authorization checks for preview realms, so it MUST stay disabled
+   * in production. For preview detection that must work in production (e.g. suppressing
+   * events), use {@link isPreviewRealmName} instead.
    */
   function isLocalPreview(realmName: string | undefined): boolean {
     if (allowLocalPreview !== 'true') return false
-    if (!realmName) return false
-    return LOCAL_PREVIEW_REALM_NAMES.includes(realmName.toLowerCase())
+    return isPreviewRealmName(realmName)
   }
 
   /**
@@ -567,6 +588,7 @@ export async function createLivekitComponent(
     buildConnectionUrl,
     deleteRoom,
     isLocalPreview,
+    isPreviewRealmName,
     updateParticipantMetadata,
     updateParticipantPermissions,
     updateRoomMetadata,

--- a/src/logic/livekit-webhook/event-handlers/participant-joined-handler.ts
+++ b/src/logic/livekit-webhook/event-handlers/participant-joined-handler.ts
@@ -21,8 +21,11 @@ export function createParticipantJoinedHandler(
       return
     }
 
-    // Do not publish events for preview realms (Creator Hub, local development)
-    if (livekit.isLocalPreview(realmName) || livekit.isLocalPreview(worldName)) {
+    // Do not publish events for preview realms (Creator Hub, local development).
+    // Detection is by realm name only and intentionally independent of the
+    // ALLOW_LOCAL_PREVIEW flag: preview sessions connect to production comms, so this
+    // must suppress events even though that flag is disabled in production.
+    if (livekit.isPreviewRealmName(realmName) || livekit.isPreviewRealmName(worldName)) {
       logger.debug(`Skipping UserJoinedRoomEvent for preview realm: ${realmName ?? worldName}`)
       return
     }

--- a/src/logic/livekit-webhook/event-handlers/participant-left-handler.ts
+++ b/src/logic/livekit-webhook/event-handlers/participant-left-handler.ts
@@ -27,8 +27,11 @@ export function createParticipantLeftHandler(
         return
       }
 
-      // Do not publish events for preview realms (Creator Hub, local development)
-      if (components.livekit.isLocalPreview(realmName) || components.livekit.isLocalPreview(worldName)) {
+      // Do not publish events for preview realms (Creator Hub, local development).
+      // Detection is by realm name only and intentionally independent of the
+      // ALLOW_LOCAL_PREVIEW flag: preview sessions connect to production comms, so this
+      // must suppress events even though that flag is disabled in production.
+      if (components.livekit.isPreviewRealmName(realmName) || components.livekit.isPreviewRealmName(worldName)) {
         logger.debug(`Skipping UserLeftRoomEvent for preview realm: ${realmName ?? worldName}`)
         return
       }

--- a/src/types/livekit.type.ts
+++ b/src/types/livekit.type.ts
@@ -36,6 +36,7 @@ export type GetRoomNameParams = { isWorld: boolean; sceneId?: string }
 
 export type ILivekitComponent = IBaseComponent & {
   isLocalPreview: (realmName: string | undefined) => boolean
+  isPreviewRealmName: (realmName: string | undefined) => boolean
   deleteRoom: (roomName: string) => Promise<void>
   buildConnectionUrl: (url: string, token: string) => string
   generateCredentials: (

--- a/test/mocks/livekit-mock.ts
+++ b/test/mocks/livekit-mock.ts
@@ -13,6 +13,10 @@ export const createLivekitMockedComponent = (
       if (!realmName) return false
       return ['localpreview', 'preview'].includes(realmName.toLowerCase())
     }),
+    isPreviewRealmName: jest.fn().mockImplementation((realmName: string | undefined) => {
+      if (!realmName) return false
+      return ['localpreview', 'preview'].includes(realmName.toLowerCase())
+    }),
     deleteRoom: jest.fn(),
     buildConnectionUrl: jest.fn(),
     generateCredentials: jest.fn(),

--- a/test/unit/livekit-adapter.spec.ts
+++ b/test/unit/livekit-adapter.spec.ts
@@ -268,6 +268,59 @@ describe('when checking if a realm is a local preview', () => {
   })
 })
 
+describe('when checking if a realm name is a preview realm', () => {
+  it('should return true for LocalPreview', () => {
+    expect(livekitComponent.isPreviewRealmName('LocalPreview')).toBe(true)
+  })
+
+  it('should return true for localpreview (lowercase)', () => {
+    expect(livekitComponent.isPreviewRealmName('localpreview')).toBe(true)
+  })
+
+  it('should return true for preview', () => {
+    expect(livekitComponent.isPreviewRealmName('preview')).toBe(true)
+  })
+
+  it('should return true for Preview (mixed case)', () => {
+    expect(livekitComponent.isPreviewRealmName('Preview')).toBe(true)
+  })
+
+  it('should return false for a production realm', () => {
+    expect(livekitComponent.isPreviewRealmName('hela')).toBe(false)
+  })
+
+  it('should return false for undefined', () => {
+    expect(livekitComponent.isPreviewRealmName(undefined)).toBe(false)
+  })
+
+  it('should return false for an empty string', () => {
+    expect(livekitComponent.isPreviewRealmName('')).toBe(false)
+  })
+
+  it('should return false for a string containing preview', () => {
+    expect(livekitComponent.isPreviewRealmName('preview-something')).toBe(false)
+  })
+
+  it('should return true even when ALLOW_LOCAL_PREVIEW is not enabled', async () => {
+    const componentWithoutPreview = await createLivekitComponent({
+      config: {
+        requireString: jest.fn().mockResolvedValue('test'),
+        getString: jest.fn().mockReturnValue(''),
+        getNumber: jest.fn().mockReturnValue(0),
+        requireNumber: jest.fn().mockResolvedValue(0)
+      },
+      logs: {
+        getLogger: jest.fn().mockReturnValue({
+          info: jest.fn(),
+          warn: jest.fn(),
+          error: jest.fn()
+        })
+      }
+    })
+    expect(componentWithoutPreview.isPreviewRealmName('localpreview')).toBe(true)
+  })
+})
+
 describe('when getting a world room name', () => {
   it('should return world room name with prefix and world name', () => {
     const worldName = 'test-world'

--- a/test/unit/livekit-webhook-event-handlers/participant-joined-handler.spec.ts
+++ b/test/unit/livekit-webhook-event-handlers/participant-joined-handler.spec.ts
@@ -525,6 +525,34 @@ describe('Participant Joined Handler', () => {
       })
     })
 
+    describe('and room is a preview realm but local preview support is disabled (production)', () => {
+      beforeEach(() => {
+        // Reproduce production: ALLOW_LOCAL_PREVIEW is off, so the gated isLocalPreview
+        // check returns false. Suppression must still happen based on the realm name alone.
+        livekit.isLocalPreview.mockReturnValue(false)
+        livekit.isPreviewRealmName.mockReturnValue(true)
+        webhookEvent.room!.name = 'preview-scene-room'
+        getRoomMetadataFromRoomNameMock.mockReturnValue({
+          sceneId: 'scene-789',
+          worldName: undefined,
+          realmName: 'LocalPreview',
+          roomType: RoomType.SCENE
+        })
+      })
+
+      it('should not publish UserJoinedRoomEvent based on the realm name alone', async () => {
+        await handler.handle(webhookEvent)
+
+        expect(publishMessagesMock).not.toHaveBeenCalled()
+      })
+
+      it('should detect the preview realm without relying on the gated isLocalPreview check', async () => {
+        await handler.handle(webhookEvent)
+
+        expect(livekit.isPreviewRealmName).toHaveBeenCalledWith('LocalPreview')
+      })
+    })
+
     describe('and message publishing fails', () => {
       let publishError: Error
       let sceneId: string

--- a/test/unit/livekit-webhook-event-handlers/participant-left-handler.spec.ts
+++ b/test/unit/livekit-webhook-event-handlers/participant-left-handler.spec.ts
@@ -341,6 +341,35 @@ describe('Participant Left Handler', () => {
         })
       })
 
+      describe('and room is a preview realm but local preview support is disabled (production)', () => {
+        beforeEach(() => {
+          // Reproduce production: ALLOW_LOCAL_PREVIEW is off, so the gated isLocalPreview
+          // check returns false. Suppression must still happen based on the realm name alone.
+          getRoomMetadataFromRoomNameMock.mockReset()
+          livekit.isLocalPreview.mockReturnValue(false)
+          livekit.isPreviewRealmName.mockReturnValue(true)
+          webhookEvent.room!.name = 'preview-scene-room'
+          getRoomMetadataFromRoomNameMock.mockReturnValue({
+            sceneId: 'scene-789',
+            worldName: undefined,
+            realmName: 'LocalPreview',
+            roomType: RoomType.SCENE
+          })
+        })
+
+        it('should not publish the user left room event based on the realm name alone', async () => {
+          await handler.handle(webhookEvent)
+
+          expect(publishMessagesMock).not.toHaveBeenCalled()
+        })
+
+        it('should detect the preview realm without relying on the gated isLocalPreview check', async () => {
+          await handler.handle(webhookEvent)
+
+          expect(livekit.isPreviewRealmName).toHaveBeenCalledWith('LocalPreview')
+        })
+      })
+
       describe('and publishing the user left room event fails', () => {
         beforeEach(() => {
           publishMessagesMock.mockRejectedValue(new Error('Failed to publish user left room event'))


### PR DESCRIPTION
## Problem

We don't want to publish `UserJoinedRoom` / `UserLeftRoom` events for users in **local preview rooms** (Creator Hub / local development). A suppression check exists in the participant joined/left webhook handlers, but it never fires in production.

The handlers gated suppression on `livekit.isLocalPreview()`, which short-circuits to `false` unless `ALLOW_LOCAL_PREVIEW === 'true'`:

```ts
function isLocalPreview(realmName: string | undefined): boolean {
  if (allowLocalPreview !== 'true') return false   // ⟵ always false in prod
  ...
}
```

`ALLOW_LOCAL_PREVIEW` is intentionally **disabled in production** — it also bypasses authentication, scene-ban enforcement and authorization for preview realms (see `comms-server-scene-handler.ts`, `comms-scene-handler.ts`), so it must stay off. Preview sessions still connect to production comms, so the events were published anyway.

We can't just flip the flag on in prod without opening an auth-bypass hole — the predicate was overloaded for two conflicting purposes.

## Fix

Split the predicate in the livekit adapter:

- **`isPreviewRealmName(realmName)`** — name-only detection, **independent of the config flag**. Grants no privileges, so it's safe to evaluate in production. The join/left handlers now use this for event suppression.
- **`isLocalPreview(realmName)`** — now layers the `ALLOW_LOCAL_PREVIEW` gate on top of `isPreviewRealmName`. Remains the predicate for the privilege-granting paths, which must stay gated in production. (Behavior unchanged.)

## Tests

The existing handler unit tests stayed green only because the livekit **mock** modeled `isLocalPreview` as a name-only check, masking the production gate.

- Added regression tests to both handler specs that reproduce production (`isLocalPreview → false`, `isPreviewRealmName → true`) and assert events are still suppressed. These fail on the old code.
- Added adapter coverage for `isPreviewRealmName`, including the case proving it returns `true` even when `ALLOW_LOCAL_PREVIEW` is disabled.

All 631 unit tests pass; typecheck and lint clean.

## Notes / out of scope

- No change needed in `decentraland/definitions` — `ALLOW_LOCAL_PREVIEW` correctly stays unset in prod, and suppression no longer depends on it.
- This only stops **future** events; previously-published preview events are not retroactively cleaned up.
- I deliberately did **not** add preview guards to `voice.ts` (`publishCommunityStreamingEndedEvent`) or `scene-bans.ts` (`publishSceneBanEvent`): community voice rooms carry no realm name and are never preview sessions, and scene bans require resolving a real Places API place + owner/admin permission, which a preview realm can't satisfy. A guard there would be unreachable dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)