### PR TITLE
fix: cancel undrained undici response bodies to prevent socket/memory leaks

### DIFF
--- a/src/adapters/fetch.ts
+++ b/src/adapters/fetch.ts
@@ -27,6 +27,9 @@ export async function cachedFetchComponent(
           const response = await fetch.fetch(url)
 
           if (!response.ok) {
+            // Release the undici response body before discarding it on the error path,
+            // otherwise the socket stays checked out of the pool with its bytes buffered.
+            await response.body?.cancel().catch(() => undefined)
             throw new Error(`Error getting ${url}, status: ${response.status}`)
           }
 

--- a/src/adapters/lands/component.ts
+++ b/src/adapters/lands/component.ts
@@ -74,6 +74,7 @@ export async function createLandsComponent(
   async function fetchAuthorizationsFromUpstream(): Promise<LandLeaseAuthorizations> {
     const response = await fetch.fetch(LEASE_AUTHORIZATIONS_URL)
     if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined)
       throw new Error(`Failed to fetch authorizations: ${response.status} ${response.statusText}`)
     }
 

--- a/src/adapters/notifications.ts
+++ b/src/adapters/notifications.ts
@@ -19,7 +19,7 @@ export async function createNotificationsComponent({
 
   async function sendNotifications(notifications: Notification[]): Promise<void> {
     logger.info(`Sending notifications to ${notifications.map((notification) => notification.address).join(', ')}`)
-    await fetch.fetch(`${notificationServiceUrl}/notifications`, {
+    const response = await fetch.fetch(`${notificationServiceUrl}/notifications`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -27,6 +27,9 @@ export async function createNotificationsComponent({
       },
       body: JSON.stringify(notifications)
     })
+    // Fire-and-forget: the response body is never read, so release it to avoid
+    // leaving the undici socket checked out of the pool with its bytes buffered.
+    await response.body?.cancel().catch(() => undefined)
   }
 
   async function sendNotificationType(

--- a/src/adapters/places.ts
+++ b/src/adapters/places.ts
@@ -52,6 +52,7 @@ export async function createPlacesComponent(
     const response = await fetch.fetch(`${placesApiUrl}/worlds/${worldId}`)
 
     if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined)
       logger.info(`No world found with name ${worldName}`)
       throw new PlaceNotFoundError(`No world found with name ${worldName}`)
     }

--- a/src/adapters/social.ts
+++ b/src/adapters/social.ts
@@ -16,6 +16,7 @@ export async function createSocialComponent(
   async function getUserPrivacySettings(address: string): Promise<PrivacySettings> {
     const response = await fetch(`${socialServiceUrl}/v1/users/${address}/privacy-settings`)
     if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined)
       logger.error(`Failed to fetch privacy settings for ${address}. Status: ${response.status}`)
       throw new Error(`Failed to fetch privacy settings for ${address}.`)
     }

--- a/src/adapters/worlds.ts
+++ b/src/adapters/worlds.ts
@@ -40,6 +40,7 @@ export async function createWorldsComponent(
     })
 
     if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined)
       logger.warn(`Failed to fetch world scene for ${worldName} at pointer ${pointer}: HTTP ${response.status}`)
       return undefined
     }
@@ -123,6 +124,7 @@ export async function createWorldsComponent(
     const url = `${worldContentUrl}/world/${worldName.toLowerCase()}/permissions/${permissionName}/address/${address.toLowerCase()}/parcels`
     const response = await fetch.fetch(url)
     if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined)
       if (response.status === 404) {
         return undefined
       }
@@ -153,6 +155,7 @@ export async function createWorldsComponent(
     })
 
     if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined)
       throw new Error(`Failed to fetch parcel permission addresses: HTTP ${response.status}`)
     }
 
@@ -170,6 +173,7 @@ export async function createWorldsComponent(
     const response = await fetch.fetch(url)
 
     if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined)
       throw new InvalidRequestError(`Failed to fetch world about for ${worldName}: HTTP ${response.status}`)
     }
 

--- a/test/integration/cached-fetch-component.spec.ts
+++ b/test/integration/cached-fetch-component.spec.ts
@@ -136,3 +136,23 @@ describe('when the response is not ok', () => {
     })
   })
 })
+
+describe('when the response is not ok and exposes a cancellable body', () => {
+  let cancelMock: jest.Mock
+
+  beforeEach(() => {
+    cancelMock = jest.fn().mockResolvedValue(undefined)
+    mockNodeFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      body: { cancel: cancelMock }
+    })
+  })
+
+  it('should release the response body before throwing', async () => {
+    await expect(cachedFunction.fetch(fetchingUrl)).rejects.toThrow(`Error getting ${fetchingUrl}`)
+
+    expect(cancelMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/unit/social-adapter.spec.ts
+++ b/test/unit/social-adapter.spec.ts
@@ -44,14 +44,23 @@ describe('when getting the privacy settings for a user', () => {
   })
 
   describe('and the request fails due to a non-200 status code', () => {
+    let cancelMock: jest.Mock
+
     beforeEach(() => {
-      fetchMock.mockResolvedValueOnce({ ok: false, status: 404 } as Response)
+      cancelMock = jest.fn().mockResolvedValue(undefined)
+      fetchMock.mockResolvedValueOnce({ ok: false, status: 404, body: { cancel: cancelMock } } as unknown as Response)
     })
 
     it('should reject, propagating the error', async () => {
       await expect(social.getUserPrivacySettings('0x123')).rejects.toThrow(
         'Failed to fetch privacy settings for 0x123.'
       )
+    })
+
+    it('should release the undici response body', async () => {
+      await expect(social.getUserPrivacySettings('0x123')).rejects.toThrow()
+
+      expect(cancelMock).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/test/unit/worlds-adapter.spec.ts
+++ b/test/unit/worlds-adapter.spec.ts
@@ -131,11 +131,14 @@ describe('worlds adapter', () => {
 
     describe('and the request fails', () => {
       let result: WorldScene | undefined
+      let cancelMock: jest.Mock
 
       beforeEach(async () => {
+        cancelMock = jest.fn().mockResolvedValue(undefined)
         mockFetch.fetch.mockResolvedValue({
           ok: false,
-          status: 500
+          status: 500,
+          body: { cancel: cancelMock }
         })
 
         result = await worldsComponent.fetchWorldSceneByPointer(worldName, pointer)
@@ -143,6 +146,10 @@ describe('worlds adapter', () => {
 
       it('should return undefined', () => {
         expect(result).toBeUndefined()
+      })
+
+      it('should release the undici response body', () => {
+        expect(cancelMock).toHaveBeenCalledTimes(1)
       })
     })
 


### PR DESCRIPTION
## Summary

Since this service moved to native `fetch` (undici, via `@dcl/traced-fetch-component` + `@dcl/core-commons`), an HTTP `Response` whose body is never consumed keeps its **pooled socket checked out** and its received **bytes buffered** until GC. Under load — especially on error/404 paths that fire routinely — this leaks connections and memory (the OOM class recently fixed upstream).

Several adapters obtained a `Response` and discarded it (returned/threw) without reading or cancelling the body. Each now releases it with `await response.body?.cancel().catch(() => undefined)` on the discard path.

### Fixed
- **`adapters/fetch.ts`** (cache `fetchMethod`) — cancels on the `!response.ok` throw. Highest leverage: backs every `*Cache.fetch(...)` (denylist, names, places, worlds permissions/scene-metadata/names, lands parcel caches).
- **`adapters/notifications.ts`** — fire-and-forget POST that never reads the body; now cancels it.
- **`adapters/worlds.ts`** — `fetchWorldSceneByPointer`, `getWorldParcelPermissions` (incl. the routine 404 path), `getWorldParcelPermissionAddresses`, `fetchWorldSceneId`.
- **`adapters/places.ts`** — `getWorldByName`.
- **`adapters/social.ts`** — `getUserPrivacySettings`.
- **`adapters/lands/component.ts`** — `fetchAuthorizationsFromUpstream`.

Sites that already call `response.json()` on every path (`places.getPlaceStatusByIds`, `names.fetchProfileBatch`) already drain the body and were left as-is. Migration scripts (`src/migrations/*`) use bare `fetch` but run once and exit, so they're not a long-running-process concern.

### Tests
Cancel-assertion regression tests added for the cache wrapper (`cached-fetch-component.spec`), `social-adapter.spec`, and `worlds-adapter.spec`, covering the throw and return-`undefined` variants. Full unit suite: **633 passing**, typecheck + lint clean.

> Related: same leak class fixed upstream in `@dcl/fetch-component` / `@dcl/http-server` (decentraland/core-components#126, decentraland/core-libs#43). Those are unpublished, and the upstream `fetch` retry-cancel only releases *intermediate* retry bodies — the final response is the caller's to drain — so these in-repo fixes are needed regardless. Bumping the `@dcl/*` deps to pick up the upstream perf/helper changes is a separate follow-up once they release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
