### PR TITLE
fix: preserve stored IP/device on null upsert of player connection info

### DIFF
--- a/src/adapters/db/player-connection-db.ts
+++ b/src/adapters/db/player-connection-db.ts
@@ -16,12 +16,18 @@ export function createPlayerConnectionDBComponent(
       // Store empty strings as null so the IP/device columns are either a usable value or
       // absent. An empty string would be persisted yet never match a ban (enforcement only
       // matches truthy identifiers), leaving inconsistent dead data.
+      //
+      // On conflict, COALESCE keeps the previously stored value when the incoming one is null:
+      // requests reach this upsert from several paths (scene-comms, private-messages) and not all
+      // carry an IP/device on every call. A null must never clobber a known identifier, or a
+      // single info-less request would erase the value a later ban relies on. A non-null incoming
+      // value still overwrites, and each column is preserved independently.
       const query = SQL`
         INSERT INTO player_connection_info (address, ip_address, device_id, created_at, updated_at)
         VALUES (${address}, ${ipAddress || null}, ${deviceId || null}, ${now}, ${now})
         ON CONFLICT (address) DO UPDATE SET
-          ip_address = EXCLUDED.ip_address,
-          device_id = EXCLUDED.device_id,
+          ip_address = COALESCE(EXCLUDED.ip_address, player_connection_info.ip_address),
+          device_id = COALESCE(EXCLUDED.device_id, player_connection_info.device_id),
           updated_at = EXCLUDED.updated_at`
       await database.query(query)
     },

--- a/src/adapters/db/types.ts
+++ b/src/adapters/db/types.ts
@@ -48,9 +48,11 @@ export type UpsertPlayerConnectionInput = {
 export interface IPlayerConnectionDBComponent {
   /**
    * Stores (or updates) the latest connection information for a player. One row per
-   * address: subsequent calls overwrite the IP, device id and updated_at timestamp.
-   * The address is stored verbatim, so callers must pass it already lowercased to keep
-   * it consistent with how it is later looked up.
+   * address: subsequent calls update the IP and device id only when a non-null value is
+   * provided, preserving the previously stored value otherwise (each column independently)
+   * so an info-less request never clears an identifier a later ban relies on. The
+   * updated_at timestamp always advances. The address is stored verbatim, so callers must
+   * pass it already lowercased to keep it consistent with how it is later looked up.
    * @param input - The address and the (optional) IP address and device id to store.
    */
   upsertPlayerConnection(input: UpsertPlayerConnectionInput): Promise<void>

--- a/test/integration/player-connection-db.spec.ts
+++ b/test/integration/player-connection-db.spec.ts
@@ -61,6 +61,60 @@ test('player connection DB component', ({ components }) => {
     })
   })
 
+  describe('when upserting over an existing row without an ip address or device id', () => {
+    beforeEach(async () => {
+      address = '0x0000000000000000000000000000000000000abc'
+      await components.playerConnectionDb.upsertPlayerConnection({
+        address,
+        ipAddress: '1.2.3.4',
+        deviceId: 'device-1'
+      })
+      await components.playerConnectionDb.upsertPlayerConnection({ address })
+    })
+
+    it('should preserve the previously stored ip address and device id', async () => {
+      const info = await components.playerConnectionDb.getByAddress(address)
+
+      expect(info).toMatchObject({ address, ipAddress: '1.2.3.4', deviceId: 'device-1' })
+    })
+  })
+
+  describe('when upserting over an existing row with empty ip address and device id', () => {
+    beforeEach(async () => {
+      address = '0x0000000000000000000000000000000000000abc'
+      await components.playerConnectionDb.upsertPlayerConnection({
+        address,
+        ipAddress: '1.2.3.4',
+        deviceId: 'device-1'
+      })
+      await components.playerConnectionDb.upsertPlayerConnection({ address, ipAddress: '', deviceId: '' })
+    })
+
+    it('should preserve the previously stored ip address and device id', async () => {
+      const info = await components.playerConnectionDb.getByAddress(address)
+
+      expect(info).toMatchObject({ address, ipAddress: '1.2.3.4', deviceId: 'device-1' })
+    })
+  })
+
+  describe('when upserting over an existing row with a new ip address but no device id', () => {
+    beforeEach(async () => {
+      address = '0x0000000000000000000000000000000000000abc'
+      await components.playerConnectionDb.upsertPlayerConnection({
+        address,
+        ipAddress: '1.2.3.4',
+        deviceId: 'device-1'
+      })
+      await components.playerConnectionDb.upsertPlayerConnection({ address, ipAddress: '5.6.7.8' })
+    })
+
+    it('should update the ip address and preserve the existing device id', async () => {
+      const info = await components.playerConnectionDb.getByAddress(address)
+
+      expect(info).toMatchObject({ address, ipAddress: '5.6.7.8', deviceId: 'device-1' })
+    })
+  })
+
   describe('when upserting without an ip address or device id', () => {
     beforeEach(async () => {
       address = '0x0000000000000000000000000000000000000abc'


### PR DESCRIPTION
## What

The `player_connection_info` upsert overwrote `ip_address` and `device_id` **unconditionally** on conflict:

```sql
ON CONFLICT (address) DO UPDATE SET
  ip_address = EXCLUDED.ip_address,
  device_id  = EXCLUDED.device_id,
  ...
```

So any token request that arrives **without** an IP/device (a path that omits the identifier, or an older client) would erase a value that a later device/IP ban relies on. Because scene-comms token requests are frequent (every realm/scene change), this clobbering is likely in practice, leaving `device_id` NULL most of the time and making device bans unreliable.

## Change

`COALESCE` each column against the existing row so:

```sql
ON CONFLICT (address) DO UPDATE SET
  ip_address = COALESCE(EXCLUDED.ip_address, player_connection_info.ip_address),
  device_id  = COALESCE(EXCLUDED.device_id,  player_connection_info.device_id),
  updated_at = EXCLUDED.updated_at
```

- A **null/absent** incoming value keeps the stored one (no more wiping).
- A **non-null** incoming value still overwrites (a genuinely new IP/device replaces the old).
- Columns are preserved **independently** (e.g. a new IP with no device updates IP, keeps device).
- `updated_at` keeps advancing as a last-seen timestamp.

## Tests

Added integration coverage to `player-connection-db.spec.ts`:
- upsert over an existing row with no IP/device → preserves both
- upsert over an existing row with empty-string IP/device → preserves both
- upsert with a new IP only → updates IP, preserves device id

`yarn typecheck` clean; 9/9 integration tests pass; eslint + prettier clean.

## Context

This is motivated by the comms-gatekeeper ↔ unity-explorer hardware-fingerprint integration. It neutralizes a data-loss aggravator where frequent info-less requests erase a stored fingerprint. Note it does **not** fix the separate field-name mismatch on the Unity scene-comms path (`hardwareFingerprint` vs. the expected `deviceIdentifier`), which is a Unity-side change.