### PR TITLE
fix(auth): upgrade crypto middleware validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@dcl/analytics-component": "^1.0.3",
     "@dcl/core-commons": "^0.10.1",
     "@dcl/crypto": "^3.4.5",
-    "@dcl/crypto-middleware": "^4.1.0",
+    "@dcl/crypto-middleware": "^5.1.0",
     "@dcl/features-component": "^1.0.1",
     "@dcl/http-commons": "^2.0.0",
     "@dcl/http-requests-logger-component": "^1.0.0",

--- a/test/integration/cast/watcher-token-handler.spec.ts
+++ b/test/integration/cast/watcher-token-handler.spec.ts
@@ -1,5 +1,7 @@
+import { Authenticator } from '@dcl/crypto'
+import { AUTH_METADATA_HEADER } from '@dcl/crypto-middleware'
 import { test } from '../../components'
-import { makeRequest } from '../../utils'
+import { admin, getAuthHeaders, makeRequest } from '../../utils'
 import { InvalidRequestError } from '../../../src/types/errors'
 
 test('Cast: Watcher Token Handler', function ({ components, spyComponents }) {
@@ -210,6 +212,34 @@ test('Cast: Watcher Token Handler', function ({ components, spyComponents }) {
       })
 
       expect(response.status).not.toBe(200)
+      expect(spyComponents.cast.generateWatcherCredentialsByLocation).not.toHaveBeenCalled()
+    })
+
+    it('should reject a scene signer signed canonically but delivered in mixed case', async () => {
+      // The signed payload is lowercased, so a spelling differing only in case shares the
+      // signature: the request stays genuinely authentic while reading differently to the
+      // `!== 'decentraland-kernel-scene'` check the authWatcher middleware gates on. Without the
+      // guard in verify() this scene request is served as if a viewer had signed it.
+      const headers = getAuthHeaders(
+        'POST',
+        '/cast/watcher-token',
+        { signer: 'decentraland-kernel-scene' },
+        (payload) => Authenticator.signPayload(admin, payload)
+      )
+      headers[AUTH_METADATA_HEADER] = JSON.stringify({ signer: 'Decentraland-Kernel-Scene' })
+
+      const response = await components.localFetch.fetch('/cast/watcher-token', {
+        method: 'POST',
+        headers: { ...headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ location: validLocation, identity: 'scene-signed' })
+      })
+
+      expect(response.status).toBe(400)
+      // The raw metadata is echoed back truncated at 64 characters, so match the prefix.
+      await expect(response.json()).resolves.toEqual({
+        ok: false,
+        message: expect.stringMatching(/^Invalid chain metadata: /)
+      })
       expect(spyComponents.cast.generateWatcherCredentialsByLocation).not.toHaveBeenCalled()
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1132,10 +1132,10 @@
     "@dcl/core-commons" "^0.10.0"
     "@dcl/crypto" "3.7.0"
 
-"@dcl/crypto-middleware@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@dcl/crypto-middleware/-/crypto-middleware-4.1.0.tgz#85b946c2627d4fbb3a91795fd78109f5cccba1e4"
-  integrity sha512-F9MVyxnLFaLJSyo5o6MtsGTDiQ1r4VqCKuFkaEPcq2JFyI6W4ftIRaKIj7hLb65PP/ywm3FkQrizSJ+6MhWpZw==
+"@dcl/crypto-middleware@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@dcl/crypto-middleware/-/crypto-middleware-5.1.0.tgz#382bc899d4f9cb07541baa7d35a4322e5810ea77"
+  integrity sha512-aiG/aInYDgL5Er+KStaIqjOmGGLlmIHSRlcAK5Jzyn+wiPU/kYiQIpMDyaIsrZ0om9HOi0M6lnqcR7ZVNpj4bA==
   dependencies:
     "@dcl/core-commons" "^0.10.0"
     "@dcl/crypto" "3.7.0"


### PR DESCRIPTION
## Summary

- upgrade `@dcl/crypto-middleware` from v4.1.0 to v5.1.0
- add a real signed-fetch regression test for mixed-case scene-signer metadata on watcher-token issuance

## Validation

- [x] `yarn build`
- [x] `yarn lint:check`
- [x] `yarn test --runInBand` (full suite, including watcher-token regression)
- [x] canonical-signer watcher-token test (12 tests)
- [ ] `yarn format:check` -- baseline formatting failures in generated `dist`/coverage output and five unrelated files; the changed watcher-token test is formatted

The regression signs canonical metadata with a real auth chain, then alters only the delivered signer casing. It verifies v5.1 rejects the still-valid signature before watcher credentials can be issued.
