### PR TITLE
fix: publish the ended event for every expired community voice chat

### DIFF
--- a/src/adapters/db/types.ts
+++ b/src/adapters/db/types.ts
@@ -29,6 +29,13 @@ export interface CommunityVoiceChatUser {
   sid?: string | null
 }
 
+/** A community voice chat room that the expiration sweep tore down. */
+export interface ExpiredCommunityVoiceChat {
+  roomName: string
+  /** Participants the room held when it was deleted. Always at least one. */
+  participantCount: number
+}
+
 export interface PlayerConnectionInfo {
   address: string
   ipAddress: string | null
@@ -201,10 +208,10 @@ export interface IVoiceDBComponent {
   deleteCommunityVoiceChat: (roomName: string) => Promise<void>
 
   /**
-   * Deletes expired community voice chats and returns the names of the rooms that were deleted.
-   * @returns The names of the rooms that were deleted.
+   * Deletes expired community voice chats and returns the rooms that were deleted.
+   * @returns The deleted rooms, each with the number of participants it had when it was deleted.
    */
-  deleteExpiredCommunityVoiceChats: () => Promise<string[]>
+  deleteExpiredCommunityVoiceChats: () => Promise<ExpiredCommunityVoiceChat[]>
 
   /**
    * Gets all active community voice chat rooms with their community IDs.
@@ -246,12 +253,4 @@ export interface IVoiceDBComponent {
       moderatorCount: number
     }>
   >
-
-  /**
-   * Gets the total participant count (all participants, not just active) for a batch of community voice chats.
-   * This is optimized for bulk queries and counts all participants regardless of their status.
-   * @param communityIds - Array of community IDs to get participant counts for.
-   * @returns Map of room name to total participant count.
-   */
-  getBulkCommunityVoiceChatParticipantCount: (communityIds: string[]) => Promise<Map<string, number>>
 }

--- a/src/adapters/db/voice-db.ts
+++ b/src/adapters/db/voice-db.ts
@@ -2,7 +2,13 @@ import SQL from 'sql-template-strings'
 import { PoolClient } from 'pg'
 import { COMMUNITY_VOICE_CHAT_ROOM_PREFIX } from '../livekit'
 import { AppComponents } from '../../types'
-import { IVoiceDBComponent, VoiceChatUser, VoiceChatUserStatus, CommunityVoiceChatUser } from './types'
+import {
+  ExpiredCommunityVoiceChat,
+  IVoiceDBComponent,
+  VoiceChatUser,
+  VoiceChatUserStatus,
+  CommunityVoiceChatUser
+} from './types'
 import { RoomDoesNotExistError } from './errors'
 
 export async function createVoiceDBComponent({
@@ -408,9 +414,10 @@ export async function createVoiceDBComponent({
   }
 
   /**
-   * Deletes expired community voice chats and returns the names of the rooms that were deleted.
+   * Deletes expired community voice chats and returns the rooms that were deleted with how many
+   * participants each one had.
    */
-  async function deleteExpiredCommunityVoiceChats(): Promise<string[]> {
+  async function deleteExpiredCommunityVoiceChats(): Promise<ExpiredCommunityVoiceChat[]> {
     const now = Date.now()
 
     // Get rooms where:
@@ -450,7 +457,16 @@ export async function createVoiceDBComponent({
       RETURNING expired_rooms.room_name`)
 
     const expiredResult = await database.query(expiredQuery)
-    return [...new Set(expiredResult.rows.map((row) => row.room_name))]
+
+    // One row per deleted participant, so the row count per room is the room's participant count.
+    // Counting here instead of with a separate query keeps the count exact: any read taken before
+    // or after the DELETE would race with participants joining or leaving.
+    const participantCountByRoom = new Map<string, number>()
+    for (const row of expiredResult.rows) {
+      participantCountByRoom.set(row.room_name, (participantCountByRoom.get(row.room_name) ?? 0) + 1)
+    }
+
+    return [...participantCountByRoom].map(([roomName, participantCount]) => ({ roomName, participantCount }))
   }
 
   function getIsConnectedQuery(now: number): string {
@@ -613,46 +629,6 @@ export async function createVoiceDBComponent({
     }))
   }
 
-  /**
-   * Gets the total participant count (all participants, not just active) for a batch of community voice chats.
-   * This is optimized for bulk queries and counts all participants regardless of their status.
-   * @param communityIds - Array of community IDs to get participant counts for.
-   * @returns Map of room name to total participant count.
-   */
-  async function getBulkCommunityVoiceChatParticipantCount(communityIds: string[]): Promise<Map<string, number>> {
-    if (communityIds.length === 0) {
-      return new Map()
-    }
-
-    // Create room names for the given community IDs
-    const roomNames = communityIds.map((id) => livekit.getCommunityVoiceChatRoomName(id))
-
-    const bulkCountQuery = SQL`
-      SELECT 
-        room_name,
-        COUNT(*) as total_participant_count
-      FROM community_voice_chat_users 
-      WHERE room_name = ANY(${roomNames})
-      GROUP BY room_name
-    `
-
-    const result = await database.query(bulkCountQuery)
-
-    const countsMap = new Map<string, number>()
-    for (const row of result.rows) {
-      countsMap.set(row.room_name, parseInt(row.total_participant_count))
-    }
-
-    // Ensure all requested rooms are in the map (with 0 if they don't exist)
-    for (const roomName of roomNames) {
-      if (!countsMap.has(roomName)) {
-        countsMap.set(roomName, 0)
-      }
-    }
-
-    return countsMap
-  }
-
   return {
     deleteExpiredPrivateVoiceChats,
     deletePrivateVoiceChat,
@@ -676,7 +652,6 @@ export async function createVoiceDBComponent({
     getAllActiveCommunityVoiceChats,
     isUserInAnyCommunityVoiceChat,
     getBulkCommunityVoiceChatStatus,
-    getBulkCommunityVoiceChatParticipantCount,
     // Export helper function for reuse
     isActiveCommunityUser: (user: CommunityVoiceChatUser, now: number) => isActiveCommunityUser(user, now)
   }

--- a/src/logic/voice/voice.ts
+++ b/src/logic/voice/voice.ts
@@ -137,8 +137,13 @@ export function createVoiceComponent(
 
   /**
    * Publishes CommunityStreamingEnded event for a community voice chat room.
+   *
+   * This is the only signal consumers get that a community voice chat is over, so every teardown
+   * path must call it. A zero participant count means nothing was actually deleted (another path
+   * already tore the room down), which is the one case where staying quiet is correct.
+   *
    * @param roomName - The name of the room.
-   * @param participantCount - The number of active participants in the room.
+   * @param participantCount - The number of participants the room had when it was deleted.
    */
   async function publishCommunityStreamingEndedEvent(roomName: string, participantCount: number): Promise<void> {
     if (participantCount === 0) {
@@ -468,19 +473,16 @@ export function createVoiceComponent(
   async function expireCommunityVoiceChats(): Promise<void> {
     logger.debug('Running community voice chat expiration job')
 
-    // Get all active community rooms to get their IDs before deletion
-    const allCommunityRooms = await voiceDB.getAllActiveCommunityVoiceChats()
-    const communityIds = allCommunityRooms.map((room) => room.communityId)
+    // The delete reports the participant count of each room it removed. Deriving it from a prior
+    // read is not an option: a room is only expired once it has no active moderator, and every
+    // "active rooms" query filters exactly those rooms out, leaving each expiry with a count of 0
+    // and its ended event unpublished.
+    const expiredRooms = await voiceDB.deleteExpiredCommunityVoiceChats()
 
-    // Get participant counts for all rooms in a single bulk query before deletion
-    const roomCounts = await voiceDB.getBulkCommunityVoiceChatParticipantCount(communityIds)
-
-    const expiredRoomNames = await voiceDB.deleteExpiredCommunityVoiceChats()
-
-    logger.debug(`Found ${expiredRoomNames.length} expired community voice chat rooms`)
+    logger.debug(`Found ${expiredRooms.length} expired community voice chat rooms`)
 
     // Delete the expired rooms from LiveKit and publish events.
-    for (const roomName of expiredRoomNames) {
+    for (const { roomName, participantCount } of expiredRooms) {
       const communityId = livekit.getCommunityIdFromRoomName(roomName)
       logger.info(`Expiring community voice chat room: ${roomName} (community: ${communityId})`)
 
@@ -490,8 +492,6 @@ export function createVoiceComponent(
 
       await livekit.deleteRoom(roomName)
 
-      // Publish event with participant count we got before deletion
-      const participantCount = roomCounts.get(roomName) || 0
       await publishCommunityStreamingEndedEvent(roomName, participantCount)
     }
   }

--- a/test/integration/voice-chat/community-voice-chat-expiration-job.spec.ts
+++ b/test/integration/voice-chat/community-voice-chat-expiration-job.spec.ts
@@ -1,8 +1,9 @@
+import { Events } from '@dcl/schemas'
 import { test } from '../../components'
 import { VoiceChatUserStatus } from '../../../src/adapters/db/types'
 import { setCommunityUserStatus } from '../../db-utils'
 
-test('Community voice chat expiration job', ({ components }) => {
+test('Community voice chat expiration job', ({ components, spyComponents }) => {
   const communityId = 'test-community-expiration'
   const moderatorAddress = '0x1234567890123456789012345678901234567890'
   const memberAddress = '0x1234567890123456789012345678901234567891'
@@ -42,7 +43,7 @@ test('Community voice chat expiration job', ({ components }) => {
       it('should NOT be deleted by the expiration job', async () => {
         // Test the direct database function - active moderator should keep room alive
         const expiredRoomsBefore = await components.voiceDB.deleteExpiredCommunityVoiceChats()
-        expect(expiredRoomsBefore).not.toContain(roomName)
+        expect(expiredRoomsBefore.map((expiredRoom) => expiredRoom.roomName)).not.toContain(roomName)
 
         // Run the full expiration job
         await components.voice.expireCommunityVoiceChats()
@@ -74,7 +75,7 @@ test('Community voice chat expiration job', ({ components }) => {
       it('should NOT be deleted by the expiration job', async () => {
         // Test the direct database function to ensure consistency - THIS WOULD HAVE FAILED BEFORE THE FIX
         const expiredRoomsBefore = await components.voiceDB.deleteExpiredCommunityVoiceChats()
-        expect(expiredRoomsBefore).not.toContain(roomName)
+        expect(expiredRoomsBefore.map((expiredRoom) => expiredRoom.roomName)).not.toContain(roomName)
 
         // Run the full expiration job
         await components.voice.expireCommunityVoiceChats()
@@ -107,7 +108,7 @@ test('Community voice chat expiration job', ({ components }) => {
       it('should be deleted by the expiration job', async () => {
         // Test the direct database function - moderator inactive beyond both TTLs
         const expiredRooms = await components.voiceDB.deleteExpiredCommunityVoiceChats()
-        expect(expiredRooms).toContain(roomName)
+        expect(expiredRooms).toContainEqual({ roomName, participantCount: 1 })
 
         // Verify the room was deleted
         const usersAfterExpiration = await components.voiceDB.getCommunityUsersInRoom(roomName)
@@ -150,7 +151,7 @@ test('Community voice chat expiration job', ({ components }) => {
         // Moderator is no longer "active" but we haven't reached the no-moderator TTL
         // Test the direct database function to ensure consistency
         const expiredRooms = await components.voiceDB.deleteExpiredCommunityVoiceChats()
-        expect(expiredRooms).not.toContain(roomName)
+        expect(expiredRooms.map((expiredRoom) => expiredRoom.roomName)).not.toContain(roomName)
 
         // Verify the room still exists
         const usersAfterExpiration = await components.voiceDB.getCommunityUsersInRoom(roomName)
@@ -181,7 +182,7 @@ test('Community voice chat expiration job', ({ components }) => {
         // Room should be destroyed - no active moderators for longer than no-moderator TTL
         // Test the direct database function to ensure consistency
         const expiredRooms = await components.voiceDB.deleteExpiredCommunityVoiceChats()
-        expect(expiredRooms).toContain(roomName)
+        expect(expiredRooms).toContainEqual({ roomName, participantCount: 1 })
 
         // Verify the room was deleted
         const usersAfterExpiration = await components.voiceDB.getCommunityUsersInRoom(roomName)
@@ -223,7 +224,7 @@ test('Community voice chat expiration job', ({ components }) => {
 
         // Test the direct database function - should delete room despite active members
         const expiredRooms = await components.voiceDB.deleteExpiredCommunityVoiceChats()
-        expect(expiredRooms).toContain(roomName)
+        expect(expiredRooms).toContainEqual({ roomName, participantCount: 2 })
 
         // Verify the room was deleted
         const usersAfterExpiration = await components.voiceDB.getCommunityUsersInRoom(roomName)
@@ -241,11 +242,41 @@ test('Community voice chat expiration job', ({ components }) => {
     it('should be deleted by the expiration job immediately', async () => {
       // Test the direct database function - no moderators should delete room immediately
       const expiredRooms = await components.voiceDB.deleteExpiredCommunityVoiceChats()
-      expect(expiredRooms).toContain(roomName)
+      expect(expiredRooms).toContainEqual({ roomName, participantCount: 1 })
 
       // Verify the room was deleted
       const usersAfterExpiration = await components.voiceDB.getCommunityUsersInRoom(roomName)
       expect(usersAfterExpiration).toHaveLength(0)
+    })
+  })
+
+  describe('when running the full expiration job over a room that has no moderators', () => {
+    beforeEach(async () => {
+      await components.voiceDB.joinUserToCommunityRoom(memberAddress, roomName, false)
+
+      spyComponents.livekit.deleteRoom.mockResolvedValue(undefined)
+      spyComponents.analytics.fireEvent.mockReturnValue(undefined)
+      spyComponents.publisher.publishMessage.mockResolvedValue({ MessageId: 'a-message-id', $metadata: {} })
+    })
+
+    afterEach(() => {
+      spyComponents.livekit.deleteRoom.mockRestore()
+      spyComponents.analytics.fireEvent.mockRestore()
+      spyComponents.publisher.publishMessage.mockRestore()
+    })
+
+    // An expiring room is by definition absent from every "active community voice chats" query, so
+    // sourcing the participant count from one used to leave the count at 0 and swallow the event.
+    it('should publish the ended event with the participants the room had', async () => {
+      await components.voice.expireCommunityVoiceChats()
+
+      expect(spyComponents.publisher.publishMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: Events.Type.STREAMING,
+          subType: Events.SubType.Streaming.COMMUNITY_STREAMING_ENDED,
+          metadata: expect.objectContaining({ communityId, totalParticipants: 1 })
+        })
+      )
     })
   })
 })

--- a/test/mocks/voice-db-mock.ts
+++ b/test/mocks/voice-db-mock.ts
@@ -27,7 +27,6 @@ export const createVoiceDBMockedComponent = (
     isActiveCommunityUser: overrides?.isActiveCommunityUser ?? jest.fn(),
     getAllActiveCommunityVoiceChats: overrides?.getAllActiveCommunityVoiceChats ?? jest.fn(),
     isUserInAnyCommunityVoiceChat: overrides?.isUserInAnyCommunityVoiceChat ?? jest.fn(),
-    getBulkCommunityVoiceChatStatus: overrides?.getBulkCommunityVoiceChatStatus ?? jest.fn(),
-    getBulkCommunityVoiceChatParticipantCount: overrides?.getBulkCommunityVoiceChatParticipantCount ?? jest.fn()
+    getBulkCommunityVoiceChatStatus: overrides?.getBulkCommunityVoiceChatStatus ?? jest.fn()
   }
 }

--- a/test/unit/voice-logic.spec.ts
+++ b/test/unit/voice-logic.spec.ts
@@ -1,6 +1,6 @@
 import { DisconnectReason } from '@livekit/protocol'
 import { ILoggerComponent } from '@well-known-components/interfaces'
-import { IVoiceDBComponent } from '../../src/adapters/db/types'
+import { ExpiredCommunityVoiceChat, IVoiceDBComponent } from '../../src/adapters/db/types'
 import { IVoiceComponent } from '../../src/logic/voice/types'
 import { createVoiceComponent } from '../../src/logic/voice/voice'
 import { ILivekitComponent, LivekitCredentials } from '../../src/types/livekit.type'
@@ -1062,114 +1062,84 @@ describe('Voice Logic Component', () => {
 
   describe('when expiring community voice chats', () => {
     let deleteExpiredCommunityVoiceChatsMock: jest.MockedFunction<IVoiceDBComponent['deleteExpiredCommunityVoiceChats']>
-    let getAllActiveCommunityVoiceChatsMock: jest.MockedFunction<IVoiceDBComponent['getAllActiveCommunityVoiceChats']>
-    let getBulkCommunityVoiceChatParticipantCountMock: jest.MockedFunction<
-      IVoiceDBComponent['getBulkCommunityVoiceChatParticipantCount']
-    >
     let publishMessageMock: jest.MockedFunction<IPublisherComponent['publishMessage']>
 
     beforeEach(() => {
       deleteExpiredCommunityVoiceChatsMock = jest.fn()
-      getAllActiveCommunityVoiceChatsMock = jest.fn()
-      getBulkCommunityVoiceChatParticipantCountMock = jest.fn()
       publishMessageMock = jest.fn()
 
       voiceDB.deleteExpiredCommunityVoiceChats = deleteExpiredCommunityVoiceChatsMock
-      voiceDB.getAllActiveCommunityVoiceChats = getAllActiveCommunityVoiceChatsMock
-      voiceDB.getBulkCommunityVoiceChatParticipantCount = getBulkCommunityVoiceChatParticipantCountMock
       publisher.publishMessage = publishMessageMock
     })
 
-    it('should get participant counts, delete expired community voice chats, destroy their rooms, and publish events', async () => {
-      const expiredRoomNames = ['voice-chat-community-room1', 'voice-chat-community-room2']
-      const communityIds = ['room1', 'room2']
-      const roomCounts = new Map<string, number>()
-      roomCounts.set(expiredRoomNames[0], 3)
-      roomCounts.set(expiredRoomNames[1], 5)
+    describe('and some community voice chats expired', () => {
+      let expiredRooms: ExpiredCommunityVoiceChat[]
 
-      getAllActiveCommunityVoiceChatsMock.mockResolvedValue(
-        communityIds.map((id) => ({
-          communityId: id,
-          participantCount: 0,
-          moderatorCount: 0
-        }))
-      )
-      getBulkCommunityVoiceChatParticipantCountMock.mockResolvedValue(roomCounts)
-      deleteExpiredCommunityVoiceChatsMock.mockResolvedValue(expiredRoomNames)
+      beforeEach(() => {
+        expiredRooms = [
+          { roomName: 'voice-chat-community-room1', participantCount: 3 },
+          { roomName: 'voice-chat-community-room2', participantCount: 5 }
+        ]
 
-      await voiceComponent.expireCommunityVoiceChats()
+        deleteExpiredCommunityVoiceChatsMock.mockResolvedValue(expiredRooms)
+      })
 
-      expect(getAllActiveCommunityVoiceChatsMock).toHaveBeenCalled()
-      expect(getBulkCommunityVoiceChatParticipantCountMock).toHaveBeenCalledWith(communityIds)
-      expect(deleteExpiredCommunityVoiceChatsMock).toHaveBeenCalled()
-      expect(deleteRoomMock).toHaveBeenCalledTimes(2)
-      expect(deleteRoomMock).toHaveBeenCalledWith(expiredRoomNames[0])
-      expect(deleteRoomMock).toHaveBeenCalledWith(expiredRoomNames[1])
-      expect(publishMessageMock).toHaveBeenCalledTimes(2)
-      expect(publishMessageMock).toHaveBeenNthCalledWith(
-        1,
-        expect.objectContaining({
-          type: 'streaming',
-          subType: 'community-streaming-ended',
-          metadata: expect.objectContaining({
-            communityId: 'room1',
-            totalParticipants: 3
+      it('should destroy the LiveKit room of every expired community voice chat', async () => {
+        await voiceComponent.expireCommunityVoiceChats()
+
+        expect(deleteRoomMock).toHaveBeenCalledTimes(2)
+        expect(deleteRoomMock).toHaveBeenCalledWith(expiredRooms[0].roomName)
+        expect(deleteRoomMock).toHaveBeenCalledWith(expiredRooms[1].roomName)
+      })
+
+      it('should publish an ended event per expired room carrying the participants it had when deleted', async () => {
+        await voiceComponent.expireCommunityVoiceChats()
+
+        expect(publishMessageMock).toHaveBeenCalledTimes(2)
+        expect(publishMessageMock).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({
+            type: 'streaming',
+            subType: 'community-streaming-ended',
+            metadata: expect.objectContaining({
+              communityId: 'room1',
+              totalParticipants: 3
+            })
           })
-        })
-      )
-      expect(publishMessageMock).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          type: 'streaming',
-          subType: 'community-streaming-ended',
-          metadata: expect.objectContaining({
-            communityId: 'room2',
-            totalParticipants: 5
+        )
+        expect(publishMessageMock).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({
+            type: 'streaming',
+            subType: 'community-streaming-ended',
+            metadata: expect.objectContaining({
+              communityId: 'room2',
+              totalParticipants: 5
+            })
           })
-        })
-      )
+        )
+      })
+
+      // The counts come straight from the delete, so an expiry can no longer be silently dropped by
+      // a separate "active rooms" read that filters out the very rooms that are expiring.
+      it('should not read the active community voice chats to resolve the participant counts', async () => {
+        await voiceComponent.expireCommunityVoiceChats()
+
+        expect(voiceDB.getAllActiveCommunityVoiceChats).not.toHaveBeenCalled()
+      })
     })
 
-    it('should handle empty expired rooms list', async () => {
-      getAllActiveCommunityVoiceChatsMock.mockResolvedValue([])
-      getBulkCommunityVoiceChatParticipantCountMock.mockResolvedValue(new Map())
-      deleteExpiredCommunityVoiceChatsMock.mockResolvedValue([])
+    describe('and no community voice chat expired', () => {
+      beforeEach(() => {
+        deleteExpiredCommunityVoiceChatsMock.mockResolvedValue([])
+      })
 
-      await voiceComponent.expireCommunityVoiceChats()
+      it('should destroy no room and publish no event', async () => {
+        await voiceComponent.expireCommunityVoiceChats()
 
-      expect(getAllActiveCommunityVoiceChatsMock).toHaveBeenCalled()
-      expect(getBulkCommunityVoiceChatParticipantCountMock).toHaveBeenCalledWith([])
-      expect(deleteExpiredCommunityVoiceChatsMock).toHaveBeenCalled()
-      expect(deleteRoomMock).not.toHaveBeenCalled()
-      expect(publishMessageMock).not.toHaveBeenCalled()
-    })
-
-    it('should not publish events for expired rooms with 0 participants', async () => {
-      const expiredRoomNames = ['voice-chat-community-room1', 'voice-chat-community-room2']
-      const communityIds = ['room1', 'room2']
-      const roomCounts = new Map<string, number>()
-      roomCounts.set(expiredRoomNames[0], 0)
-      roomCounts.set(expiredRoomNames[1], 0)
-
-      getAllActiveCommunityVoiceChatsMock.mockResolvedValue(
-        communityIds.map((id) => ({
-          communityId: id,
-          participantCount: 0,
-          moderatorCount: 0
-        }))
-      )
-      getBulkCommunityVoiceChatParticipantCountMock.mockResolvedValue(roomCounts)
-      deleteExpiredCommunityVoiceChatsMock.mockResolvedValue(expiredRoomNames)
-
-      await voiceComponent.expireCommunityVoiceChats()
-
-      expect(getAllActiveCommunityVoiceChatsMock).toHaveBeenCalled()
-      expect(getBulkCommunityVoiceChatParticipantCountMock).toHaveBeenCalledWith(communityIds)
-      expect(deleteExpiredCommunityVoiceChatsMock).toHaveBeenCalled()
-      expect(deleteRoomMock).toHaveBeenCalledTimes(2)
-      expect(deleteRoomMock).toHaveBeenCalledWith(expiredRoomNames[0])
-      expect(deleteRoomMock).toHaveBeenCalledWith(expiredRoomNames[1])
-      expect(publishMessageMock).not.toHaveBeenCalled()
+        expect(deleteRoomMock).not.toHaveBeenCalled()
+        expect(publishMessageMock).not.toHaveBeenCalled()
+      })
     })
   })
 


### PR DESCRIPTION
## Problem

`expireCommunityVoiceChats` resolved each room's participant count from `getAllActiveCommunityVoiceChats`. That query ends in `HAVING active_moderator_count > 0` — it only returns rooms that still have an active moderator, which is exactly what an expiring room does not have.

Every expiry therefore looked up a count of `0`, and `publishCommunityStreamingEndedEvent` treats `0` as "another path already tore this room down" and stays quiet:

```ts
const participantCount = roomCounts.get(roomName) || 0   // always 0 for an expired room
await publishCommunityStreamingEndedEvent(roomName, participantCount)   // early-returns
```

The result is that the most common silent end of a community voice chat — the host drops off the network and the room expires five minutes later — published nothing at all. Of the four teardown paths, this was the only one that never emitted its event.

## Fix

`deleteExpiredCommunityVoiceChats` already runs `DELETE ... RETURNING` and gets back one row per deleted participant, so it now counts them per room and returns `{ roomName, participantCount }[]`.

That kills the broken query outright, and the count is exact by construction: any read taken before or after the `DELETE` would race with participants joining and leaving.

`getBulkCommunityVoiceChatParticipantCount` had no other caller and is removed.

The `participantCount === 0` guard in `publishCommunityStreamingEndedEvent` stays — it is a genuine "already torn down" check, since a live room always has at least one row in `community_voice_chat_users`. Only the number being fed to it was wrong.

## Tests

- New integration test runs the full expiration job and asserts the event is published with the participants the room actually had. It fails on the code before this change.
- The expiration integration tests now pin the participant count as well as the room name.
- Unit coverage for the expiration path was rewritten around the new return shape, including that it no longer reads the active-rooms query to resolve counts.

Full suite: 1251 passed, 2 skipped.

## Rollout

This should be deployed **before** decentraland/social-service-ea#480, which removes that service's 45-second poller and relies on this event as the only signal that a community voice chat ended. Landing them the other way round would leave expired rooms unreported with no poller to catch them.

Related:
- decentraland/social-service-ea#480
- decentraland/definitions#1670
